### PR TITLE
Buffer support for Multipart generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,11 @@ client.post('http://my.app.com', data, function(err, resp, body){
 ### Multipart POST
 
 ``` js
+var base64_input = new Buffer(form_image_input.replace(/^data:image\/\w+;base64,/, ""), "base64");
 var data = {
   foo: bar,
-  image: { file: '/home/tomas/linux.png', content_type: 'image/png' }
+  image: { file: '/home/tomas/linux.png', content_type: 'image/png' },
+  gif: { buffer: base64_input, content_type: 'image/gif' }
 }
 
 var options = {

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -52,7 +52,7 @@ function flatten(object, into, prefix){
 		var prefix_key = prefix ? prefix + "[" + key + "]" : key;
 		var prop = object[key];
 
-		if(prop && typeof prop === "object" && !(prop.file && prop.content_type))
+		if(prop && typeof prop === "object" && !((prop.buffer || prop.file) && prop.content_type))
 			flatten(prop, into, prefix_key)
 		else
 			into[prefix_key] = prop;
@@ -192,7 +192,7 @@ var Needle = {
 
 			var value = object[key];
 			if(value !== null && typeof value != 'undefined'){
-				var part = value.file && value.content_type ? value : {value: value};
+				var part = (value.buffer || value.file) && value.content_type ? value : {value: value};
 				body += this.generate_part(key, part, boundary);
 			}
 
@@ -207,10 +207,18 @@ var Needle = {
 		var return_part = '--' + boundary + "\r\n";
 		return_part += "Content-Disposition: form-data; name=\"" + name + "\"";
 
-		if(part.file && part.content_type){
+		if((part.file || part.buffer) && part.content_type){
 
-			var filename = path.basename(part.file);
-			var data = fs.readFileSync(part.file);
+			var filename,
+					data;
+
+			if(part.file){
+				filename = path.basename(part.file);
+				data = fs.readFileSync(part.file);
+			} else {
+				filename = part.filename;
+				data = part.buffer;
+			}
 
 			return_part += "; filename=\"" + filename + "\"\r\n";
 			return_part += "Content-Type: " + part.content_type + "\r\n\r\n";

--- a/test/test.js
+++ b/test/test.js
@@ -42,6 +42,8 @@ function multipart_post(){
 	var data = 'Plain text data.\nLorem ipsum dolor sit amet.\nBla bla bla.\n';
 	fs.writeFileSync(filename, data);
 
+	var black_pixel = new Buffer("data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=".replace(/^data:image\/\w+;base64,/, ""), "base64");
+
 	var data = {
 		foo: 'bar',
 		bar: 'baz',
@@ -50,7 +52,8 @@ function multipart_post(){
 			even: {
 				more: 'nesting'
 			}
-		}
+		},
+    buffer: { filename:'black_pixel.gif', buffer:black_pixel, content_type: 'image/gif' },
 	}
 
 	client.post('http://posttestserver.com/post.php?dir=example', data, {multipart: true}, function(err, resp, body){


### PR DESCRIPTION
I recently needed the ability to accept a Base64 input and immediately pass it on to a 3rd party service.

Rather than writing the data to disk just to send it off and delete it, I added the ability to pass the raw file contents directly to Needle so that it can properly encode the data in its Multipart construction.

This can be done by specifying a `buffer` attribute (as opposed to the `file` file path attribute):

```
var base64_input = new Buffer(form_image_input.replace(/^data:image\/\w+;base64,/, ""), "base64");
var data = {
  foo: bar,
  image: { file: '/home/tomas/linux.png', content_type: 'image/png' },
  gif: { buffer: base64_input, content_type: 'image/gif' }
}
```
