### PR TITLE
"Host" header must contain port otherwise request is performed to standard port

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -66,13 +66,13 @@ var Needle = {
 	default_user_agent: default_user_agent,
 
 	request: function(uri, method, data, options, callback){
-
+		method = method || 'GET';
+		
 		var self = this, post_data = null;
 		var callback = (typeof options == 'function') ? options : callback;
 		var options = options || {};
 		if(uri.indexOf('http') == -1) uri = 'http://' + uri;
 
-		var method = options.method || 'GET';
 		var request_compressed = (options.compressed && typeof unzip != 'undefined') || false;
 
 		var config = {


### PR DESCRIPTION
Currently requests like this are using 80/443 port

``` javascript
needle.post("http://sampledomain.com:3000/app/create/", {
    "foo" : "bar"
}, {
    headers : {
        "Authoriation" : token
    }
}, function(err, res, body) {
    console.log(body);
});
```
