### PR TITLE
encode part.value to 'binary' in multipart post

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -262,7 +262,7 @@ var Needle = {
     } else {
 
       return_part += "\r\n\r\n";
-      return_part += part.value;
+      return_part += new Buffer(part.value, 'utf-8').toString('binary');
       append();
 
     }


### PR DESCRIPTION
Otherwise, unicode character will be unrecognizable in server side.

Client code sample:

```
var data = {};
data.content = '中文';
needle.post(SERVER_URL, data, {multipart: true});
```

Charactor display in server:

```
-�
```

Fix outside needle:

```
var data = {};
var content = '中文';
data.content = new Binary(content, 'utf-8').toString('binary');
needle.post(SERVER, data, {multipart: true});
```

In javascript, string is 'utf-8' by default, so I think it's better to fix this in needle as in my commits 
