### PR TITLE
Added option for http port different from default 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Request options
  - `proxy`: Forwards request through HTTP proxy. Eg. `proxy: 'http://proxy.server.com:3128'`
  - `agent`: Uses an http.Agent of your choice, instead of the global (default) one.
  - `headers`: Object containing custom HTTP headers for request. Overrides defaults described below.
+ * `port`: Optional port for http . Defaults to 80. (agnunez)
+
 
 Response options
 ----------------
@@ -53,6 +55,7 @@ These are basically shortcuts to the `headers` option described above.
  - `accept`: Sets 'Accept' HTTP header. Defaults to `*/*`.
  - `connection`: Sets 'Connection' HTTP header. Defaults to `close`.
  - `user_agent`: Sets the 'User-Agent' HTTP header. Defaults to `Needle/{version} (Node.js {node_version})`.
+ * `port`: Optional port for http . Defaults to 80. (agnunez)
 
 Node.js TLS Options
 -------------------
@@ -95,6 +98,14 @@ needle.get('http://www.google.com/search?q=syd+barrett', function(err, resp, bod
 
 ``` js
 needle.get('https://api.server.com', { username: 'you', password: 'secret' },
+  function(err, resp, body){
+    // used HTTP auth
+});
+
+### HTTP POST with Basic Auth, parameters and different port (agnunez)
+
+``` js
+needle.post('https://api.server.com', 'par=value', { username: 'you', password: 'secret', port: 8000 },
   function(err, resp, body){
     // used HTTP auth
 });

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -12,6 +12,8 @@ var fs = require('fs'),
     stringify = require('qs').stringify,
     multipart = require('./multipart');
 
+var optport;		// added option for http port option;
+
 var version = JSON.parse(fs.readFileSync(__dirname + '/../package.json').toString()).version,
     debug = !!process.env.DEBUG;
 
@@ -78,7 +80,8 @@ var Needle = {
     config.headers = {
       'Accept': options.accept || '*/*',
       'Connection': options.connection || 'close',
-      'User-Agent': options.user_agent || this.default_user_agent
+      'User-Agent': options.user_agent || this.default_user_agent,
+      'Port': options.port || 80			// added http port option. agnunez
     }
 
     if (options.compressed && typeof unzip != 'undefined')
@@ -86,6 +89,8 @@ var Needle = {
 
     for (var h in options.headers)
       config.headers[h] = options.headers[h];
+
+    optport = options.port ? options.port : 80;		// added http port option. agnunez
 
     if (options.username && options.password){
       var b = new Buffer([options.username, options.password].join(':'));
@@ -107,7 +112,7 @@ var Needle = {
         });
 
       } else {
-        post_data = (typeof(data) === 'string') ? data : stringify(data);
+        post_data = (typeof(data) === "string") ? data : stringify(data);
         config.headers['Content-Type'] = 'application/x-www-form-urlencoded';
         config.headers['Content-Length'] = post_data.length;
       }
@@ -123,7 +128,7 @@ var Needle = {
 
     opts.protocol = remote.protocol;
     opts.host     = remote.hostname;
-    opts.port     = remote.port || (remote.protocol == 'https:' ? 443 : 80);
+    opts.port     = remote.port || (remote.protocol == 'https:' ? 443 : optport);  // added http port option. agnunez
     opts.path     = proxy ? uri : remote.pathname + (remote.search || '');
     opts.method   = method;
     opts.headers  = config.headers;
@@ -246,11 +251,6 @@ var Needle = {
 
 }
 
-var is_valid_data = function(obj) {
-  return typeof obj === 'string'
-      || (obj.toString() === '[object Object]' && Object.keys(obj).length > 0);
-}
-
 exports.head = function(uri, options, callback){
   return Needle.request(uri, 'HEAD', null, options, callback);
 }
@@ -260,12 +260,12 @@ exports.get = function(uri, options, callback){
 }
 
 exports.post = function(uri, data, options, callback){
-  if (!data || !is_valid_data(data)) throw('POST request expects data.');
+  if (!data || typeof data == 'function') throw('POST request expects data.');
   return Needle.request(uri, 'POST', data, options, callback);
 }
 
 exports.put = function(uri, data, options, callback){
-  if (!data || !is_valid_data(data)) throw('PUT request expects data.');
+  if (!data || typeof data == 'function') throw('PUT request expects data.');
   return Needle.request(uri, 'PUT', data, options, callback);
 }
 


### PR DESCRIPTION
Hi,

I didn't find the way to use a different port from 80. I did a q&d change, I'm sure you can integrate better, but now I can use for post an auth form into a 8xxx port like:

 needle.post('http://url/path', 'par1=val1&par2=val2', { username: 'user', password: 'pass', port: 8000},

That is what I needed to control some arduinos ( i cannot use https with them).

Hope you integrate it better in your excellent needle.

Agustin
anunez@gmail.com
agnunez (github)
