### PR TITLE
Update lib/needle.js

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -109,7 +109,6 @@ var Needle = {
         post_data = (typeof(data) === 'string') ? data : JSON.stringify(data);
         config.headers['Content-Type'] = 'application/json';
         config.headers['Content-Length'] = post_data.length;
-      }
       } else {
         post_data = (typeof(data) === 'string') ? data : stringify(data);
         config.headers['Content-Type'] = 'application/x-www-form-urlencoded';


### PR DESCRIPTION
I was having some issues posting to some API's with form-url-encoded data, when the whole thing needed to be sent as JSON. This was the only way I could fix this. I couldn't override the content-type any other way. Is there a more elegant solution than this?
