### PR TITLE
Pass secureProtocol TLS option through to the https module for Needle requests

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -21,7 +21,7 @@ try { var unzip = require('zlib').unzip } catch(e) { /* zlib not supported */ }
 var default_user_agent = "Needle/" + version;
 default_user_agent += " (Node.js " + process.version + "; " + process.platform + " " + process.arch + ")";
 
-var node_tls_opts = 'agent pfx key passphrase cert ca ciphers rejectUnauthorized';
+var node_tls_opts = 'agent pfx key passphrase cert ca ciphers rejectUnauthorized secureProtocol';
 
 var parsers = {
   'application/json': function(data, callback){


### PR DESCRIPTION
It is possible to run into an issue such as this that will prevent requests against a buggy server from working:

http://carnivore.it/2011/10/07/error_14077458_ssl_routines_ssl23_get_server_hello_reason_1112

The solution is to force SSLv3. This can be done with a mostly undocumented feature of Node.js by doing something like the following:

``` javascript
var options = {
  ...
  secureProtocol: 'SSLv3_method',
  agent: false
}
var req = https.request(options, function(res) {
  ...
});
```

This change to Needle allows that option to be passed through.
