### PR TITLE
Incorrect - Content-Length

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -138,7 +138,8 @@ var Needle = {
           ? 'application/json'
           : 'application/x-www-form-urlencoded';
         }
-
+        
+        post_data = new Buffer(post_data, config.encoding)
         config.headers['Content-Length'] = post_data.length;
       }
     }


### PR DESCRIPTION
`headers['Content-Length']` is incorrect for some characters.
You can try this with a little experiment.

``` javascript
> new Buffer('English', 'utf8').length
7
> 'English'.length
7
> new Buffer('ひらかな', 'utf8').length
12
> 'ひらかな'.length
4
```

I recommend you fix this by encoding the content into node.js Buffer before measure its length.
