### PR TITLE
Things like node-replay fail when incoming chunk is not a buffer

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -257,6 +257,9 @@ var Needle = {
         resp.bytes = length;
         resp.body  = new Buffer(resp.bytes);
         for (var i = 0, len = chunks.length; i < len; i++) {
+          if (typeof chunks[i] !== "object") {
+            chunks[i] = new Buffer(chunks[i]);
+          }
           chunks[i].copy(resp.body, pos);
           pos += chunks[i].length;
         }


### PR DESCRIPTION
Force the response to become a buffer if it isn't one already so copy() doesn't fail.
