### PR TITLE
auth doesn't require password

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -122,7 +122,7 @@ var Needle = {
     for (var h in options.headers)
       config.headers[h] = options.headers[h];
 
-    if (options.username && options.password) {
+    if (options.username) {
       if (options.auth && (options.auth == 'auto' || options.auth == 'digest')) {
         config.credentials = [options.username, options.password];
       } else {


### PR DESCRIPTION
Allowing send auth requests without having to enter a password.
