### PR TITLE
Convert chunks to Buffer to use copy

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -257,7 +257,7 @@ var Needle = {
         resp.bytes = length;
         resp.body  = new Buffer(resp.bytes);
         for (var i = 0, len = chunks.length; i < len; i++) {
-          chunks[i].copy(resp.body, pos);
+          (new Buffer(chunks[i])).copy(resp.body, pos);
           pos += chunks[i].length;
         }
 


### PR DESCRIPTION
The chunk argument can be either a String or a Buffer. In the case of node-replay, a String is passed. In order to use the copy function the String must be converted to a Buffer.
