### PR TITLE
options.password should not be required for basic auth

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -126,7 +126,10 @@ var Needle = {
     for (var h in options.headers)
       config.headers[h] = options.headers[h];
 
-    if (options.username && options.password) {
+    if (options.username) {
+      if (typeof options.password == 'undefined') {
+        options.password = '';
+      }
       if (options.auth && (options.auth == 'auto' || options.auth == 'digest')) {
         config.credentials = [options.username, options.password];
       } else {


### PR DESCRIPTION
API for Pushbullet (https://www.pushbullet.com/api) uses basic auth for authentication. API key is set for "username", but the "password" field has to be empty.
