### PR TITLE
Catch xml2js errors caused by sax

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "needle"
-  , "version": "0.6.7"
+  , "version": "0.6.6"
   , "description": "Tiny yet feature-packed HTTP client. With multipart, charset decoding and proxy support."
   , "keywords": ["http", "https", "simple", "request", "client", "multipart", "upload", "proxy", "deflate", "timeout", "charset", "iconv"]
   , "tags": ["http", "https", "simple", "request", "client", "multipart", "upload", "proxy", "deflate", "timeout", "charset", "iconv"]


### PR DESCRIPTION
xml2js fails to call the callback function with  err set in case of parse errors, because sax.js throws a global error (Line 912 sax.js). 
This throwed error is never catched and therefore bumps at top level, so its not possible to do a needle call with automatic xml parsing. (One has to switch off parsing).

This patch catches the error and calls the callback in the intended way.
