### PR TITLE
Implements strict-mode for parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+<a name='v0.7' /> Upgrading from v0.6 to v0.7
+---------------------------------------------
+
+In version 0.7 a lot of work was done on the Needle internals to make streams a first class citizen. Needle can now be used as a streams2-compatible stream and you gain a lot of performance improvements come with it.
+
+While great care was taken not to introduce any breaking changes, there are probably a few edge cases in which Needle's behaviour has changed, specifically:
+
+ * Needle now emits a strict streams2-compatible stream. This means that if your code relied on the Needle stream to always be in flowing mode, your code will likely need an update. For more information about this new Stream behavior, please refer to [the Node.JS blog](http://blog.nodejs.org/2012/12/20/streams2/).
+
+ * In the v0.6 release, Needle's stream didn't parse, uncompress or did anything to the body content: everything chunk of data that was emitted on the stream was the raw body. In the 0.7 release every chunk of data will be a fully processed chunk, including uncompression, character recoding and parsing (in case of XML/JSON).
+ 
+ * In the v0.6 release, the HTTP body was always buffered and processed, regardless of whether or not you are using streams. This means that if you did weird things to a response even when using streams, your code will likely break. To illustrate:
+
+```javascript
+ var res;
+ var stream = Needle.get('http://www.google.com/');
+ stream.on('response', function (response) { 
+   res = response;
+ });
+ stream.on('end', function () {
+   // In version 0.7, res.body will be null.
+   console.log(res.body);
+ });
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,16 @@ While great care was taken not to introduce any breaking changes, there are prob
  
  * In the v0.6 release, the HTTP body was always buffered and processed, regardless of whether or not you are using streams. This means that if you did weird things to a response even when using streams, your code will likely break. To illustrate:
 
-```javascript
- var res;
- var stream = Needle.get('http://www.google.com/');
- stream.on('response', function (response) { 
-   res = response;
- });
- stream.on('end', function () {
-   // In version 0.7, res.body will be null.
-   console.log(res.body);
- });
-```
+  ```javascript
+   var res;
+   var stream = Needle.get('http://www.google.com/');
+   stream.on('response', function (response) { 
+     res = response;
+   });
+   stream.on('end', function () {
+     // In version 0.7, res.body will be null.
+     console.log(res.body);
+   });
+  ```
 
 If you use the regular callback interface of Needle, this will be a backwards-compatible upgrade.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name='v0.7' /> Upgrading from v0.6 to v0.7
----------------------------------------------
+<a name='v0.7' /> Api changes between v0.6 and v0.7
+---------------------------------------------------
 
 In version 0.7 a lot of work was done on the Needle internals to make streams a first class citizen. Needle can now be used as a streams2-compatible stream and you gain a lot of performance improvements come with it.
 
@@ -22,3 +22,5 @@ While great care was taken not to introduce any breaking changes, there are prob
    console.log(res.body);
  });
 ```
+
+If you use the regular callback interface of Needle, this will be a backwards-compatible upgrade.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Needle
 
 [![NPM](https://nodei.co/npm/needle.png)](https://nodei.co/npm/needle/)
 
+**Current stable version is 0.7** Please read [Api changes between v0.6 and v0.7](CHANGELOG.md#v0.7), and update your programs accordingly.
 
 The leanest and most handsome HTTP client in the Nodelands. With only two dependencies, it supports: 
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Response options
 
  - `decode`    : Whether to decode the text responses to UTF-8, if Content-Type header shows a different charset. Defaults to `true`.
  - `parse`     : Whether to parse XML or JSON response bodies automagically. Defaults to `true`.
+ - `strict`    : When parsing or decoding text responses, be very strict about accepted characters. Defaults to `false`.
  - `output`    : Dump response output to file. This occurs after parsing and charset decoding is done.
 
 Note: To stay light on dependencies, Needle doesn't include the `xml2js` module used for XML parsing. To enable it, simply do `npm install xml2js`.

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -62,7 +62,8 @@ var defaults = {
   parse_response  : true,
   timeout         : 10000,
   encoding        : 'utf8',
-  boundary        : '--------------------NODENEEDLEHTTPCLIENT'
+  boundary        : '--------------------NODENEEDLEHTTPCLIENT',
+  strict          : false
 }
 
 //////////////////////////////////////////
@@ -87,6 +88,7 @@ var Needle = {
       encoding        : options.encoding || (options.multipart ? 'binary' : defaults.encoding),
       decode_response : options.decode === false ? false : defaults.decode_response,
       parse_response  : options.parse === false ? false : defaults.parse_response,
+      strict          : options.strict === true ? true : defaults.strict,
       follow          : options.follow === true ? 10 : typeof options.follow == 'number' ? options.follow : defaults.follow,
       timeout         : (typeof options.timeout == 'number') ? options.timeout : defaults.timeout
     }
@@ -255,9 +257,18 @@ var Needle = {
           // TODO: in case of error, this emits 'error' on the stream -- is this
           // what we want?
           try {
-            pipeline.push(require('iconv').Iconv(response_opts.charset, 'UTF-8'))
+            var target = 'UTF-8';
+
+            if (response_opts.strict === false) {
+              // Unless we're in strict mode, try to loosely transcode characters when
+              // no exact match is found, and ignore unmatched characters.
+              target = target.concat('//TRANSLIT//IGNORE')
+            }
+            
+            pipeline.push(require('iconv').Iconv(response_opts.charset, target));
           } catch (err) {
-            debug(err.message);
+            // Iconv not found.
+            debug('Iconv not found: ', err.message);
           }
         }
       }

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -255,7 +255,7 @@ var Needle = {
           // TODO: in case of error, this emits 'error' on the stream -- is this
           // what we want?
           try {
-            pipeline.push(require('iconv').Iconv('UTF-8', response_opts.charset))
+            pipeline.push(require('iconv').Iconv(response_opts.charset, 'UTF-8'))
           } catch (err) {
             debug(err.message);
           }


### PR DESCRIPTION
Iconv has the ability to 'loosely' transcode characters if it would normally fail. For example, if you're converting a `ç` character to `c` in case of latin1.

This patch adds a 'strict' response option. Other parsers can use this functionality to decide whether or not to fail when encountering an error.