### PR TITLE
Implements #53

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -190,6 +190,16 @@ var Needle = {
         protocol           = request_opts.protocol == 'https:' ? https : http,
         callback_requested = (callback ? true : false);
 
+    if (callback_requested && callback.length == 3) {
+      debug('warning: using deprecated callback interface');
+
+      // Decorator for callback for backwards-compatibility
+      var orig = callback;
+      callback = function (err, response) {
+        return orig(err, response, response.body);
+      }
+    }
+
     // set the out stream variable in the config object to avoid instantiating
     // multiple streams when hitting redirects.
     config.out = config.out || new stream.PassThrough({ objectMode: false });
@@ -304,7 +314,7 @@ var Needle = {
               resp.body = resp.body.toString();
           }
 
-          callback(null, resp, resp.body);
+          callback(null, resp);
         });
 
       };

--- a/test/iconv_spec.js
+++ b/test/iconv_spec.js
@@ -18,7 +18,7 @@ describe('character encoding', function(){
 
       var results = tasks.map(function (task) {
         return task.then(function (obj) {
-          return obj[0].body;
+          return obj.body;
         });
       });
 


### PR DESCRIPTION
Implements 2-argument callback instead of 3-argument callback as
discussed in #53. The updated test specification is an example of
the issues the 2-argument callback was raising.
