### PR TITLE
default json charset US-ASCII to UTF-8

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -150,8 +150,8 @@ var Needle = {
 
         if (!config.headers['Content-Type']) {
           config.headers['Content-Type'] = options.json
-          ? 'application/json'
-          : 'application/x-www-form-urlencoded';
+          ? 'application/json; charset=utf-8'
+          : 'application/x-www-form-urlencoded; charset=utf-8';
         }
 
         post_data = new Buffer(post_data, config.encoding);


### PR DESCRIPTION
Characters will be garbled if the JSON request containing a multi-byte character. 
It is for a server to misunderstand the character code of a request. 

'Content-Type: application/json' -> charset default(US-ASCII)
'Content-TYpe: application/json; charset=utf-8' -> charset UTF-8

For example, if a multi-byte character is called by [hipchatter](https://www.npmjs.org/package/hipchatter), a hipchat server will receive an unjust demand. 

In `json:true`, please set a default to `charset=utf-8`. 