### PR TITLE
Default charset set to UTF-8 and charset is not always the second param of header

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -359,8 +359,9 @@ var Needle = {
   parse_content_type: function(header) {
     if (!header || header == '') return {};
 
-    var charset = 'iso-8859-1', arr = header.split(';');
-    try { charset = arr[1].match(/charset=(.+)/)[1] } catch (e) { /* not found */ }
+    var charset = 'utf-8';
+    var arr = header.split(';');
+    try { charset = header.match(/charset=([^;]+)/)[1] } catch (e) { /* not found */ }
 
     return { type: arr[0], charset: charset };
   },


### PR DESCRIPTION
 - set default charset to utf-8
 - update charset matching pattern