### PR TITLE
Fix global scope leak

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -199,7 +199,7 @@ var Needle = {
   send_request: function(count, method, uri, config, post_data, out, callback) {
 
     var timer,
-        returned     = 0
+        returned     = 0,
         self         = this,
         request_opts = this.get_request_opts(method, uri, config),
         protocol     = request_opts.protocol == 'https:' ? https : http;
@@ -330,7 +330,7 @@ var Needle = {
 
             // if we're here and parsed is true, it means we tried to but it didn't work.
             // so given that we got a text response, let's stringify it.
-            if (text_response || parsed) { 
+            if (text_response || parsed) {
               resp.body = resp.body.toString();
             }
           }


### PR DESCRIPTION
A missing comma leaks a few variables into the global namespace. This PR fixes the issue.
