### PR TITLE
Adding ability to send node.js Buffer

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -360,12 +360,7 @@ var Needle = {
       if (this.is_stream(post_data)) {
         post_data.pipe(request);
       } else {
-        if (Buffer.isBuffer(post_data)) {
-          request.write(post_data);
-        } else {
-          request.write(post_data, config.encoding);
-        }
-
+        request.write(post_data, config.encoding);
         request.end();
       }
     } else {


### PR DESCRIPTION
As far as I could tell, sending a raw binary `Buffer` is not currently doable in needle, but it can be supported with very little modification.
