### PR TITLE
Added Support for Basic Auth in URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@ needle.get('https://api.server.com', { username: 'you', password: 'secret' },
 });
 ```
 
+Or use [RFC-1738](http://tools.ietf.org/html/rfc1738#section-3.1) basic auth URL syntax:
+
+```js
+needle.get('https://username:password@api.server.com', function(err, resp) {
+    // used HTTP auth from URL
+});
+```
+
 ### Digest Auth
 
 ```js

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -195,8 +195,6 @@ var Needle = {
             opts.headers['Host'] += ':' + opts.port;
     }
 
-
-
     return opts;
   },
 

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -117,6 +117,15 @@ var Needle = {
         var auth_header = options.proxy ? 'Proxy-Authorization' : 'Authorization';
         config.headers[auth_header] = auth.basic(options.username, options.password);
       }
+    } else {
+        // Check for basic auth in the URL - support for http://tools.ietf.org/html/rfc1738#section-3.1 CISS
+        var parts = url.parse(uri);
+        if (parts.auth) {
+            var creds = parts.auth.split(':').map(function(i){ return decodeURIComponent(i); });
+            options.username = creds[0];
+            options.password = creds[1] || '';
+            config.headers['Authorization'] = auth.basic(options.username, options.password);
+        }
     }
 
     if (data) {
@@ -185,6 +194,8 @@ var Needle = {
         if (opts.port != 80 && opts.port != 443)
             opts.headers['Host'] += ':' + opts.port;
     }
+
+
 
     return opts;
   },

--- a/test/basic_auth_spec.js
+++ b/test/basic_auth_spec.js
@@ -121,6 +121,31 @@ describe('Basic Auth', function() {
 
   })
 
+  describe('when username AND password are non empty strings', function() {
+
+    var opts = { username: 'foobar', password: 'jakub', parse: true };
+
+    it('sends Authorization header', function(done) {
+      needle.get('localhost:' + port, opts, function(err, resp) {
+        var sent_headers = resp.body.headers;
+        Object.keys(sent_headers).should.containEql('authorization');
+        done();
+      })
+    })
+
+    it('Basic Auth only includes both user and password', function(done) {
+      needle.get('localhost:' + port, opts, function(err, resp) {
+        var sent_headers = resp.body.headers;
+        var auth = get_auth(sent_headers['authorization']);
+        auth[0].should.equal('foobar');
+        auth[1].should.equal('jakub');
+        auth.should.have.lengthOf(2);
+        done();
+      })
+    })
+
+  })
+
   describe('when username/password are included in URL', function() {
 
     var opts = { username: 'foobar', password: 'jakub', parse: true };

--- a/test/basic_auth_spec.js
+++ b/test/basic_auth_spec.js
@@ -27,7 +27,7 @@ describe('Basic Auth', function() {
     it('doesnt send any Authorization headers', function(done) {
       needle.get('localhost:' + port, { parse: true }, function(err, resp) {
         var sent_headers = resp.body.headers;
-        Object.keys(sent_headers).should.not.include('authorization');
+        Object.keys(sent_headers).should.not.containEql('authorization');
         done();
       })
     })
@@ -41,7 +41,7 @@ describe('Basic Auth', function() {
     it('doesnt send any Authorization headers', function(done) {
       needle.get('localhost:' + port, { parse: true }, function(err, resp) {
         var sent_headers = resp.body.headers;
-        Object.keys(sent_headers).should.not.include('authorization');
+        Object.keys(sent_headers).should.not.containEql('authorization');
         done();
       })
     })
@@ -55,7 +55,7 @@ describe('Basic Auth', function() {
     it('sends Authorization header', function(done) {
       needle.get('localhost:' + port, opts, function(err, resp) {
         var sent_headers = resp.body.headers;
-        Object.keys(sent_headers).should.include('authorization');
+        Object.keys(sent_headers).should.containEql('authorization');
         done();
       })
     })
@@ -79,7 +79,7 @@ describe('Basic Auth', function() {
     it('sends Authorization header', function(done) {
       needle.get('localhost:' + port, opts, function(err, resp) {
         var sent_headers = resp.body.headers;
-        Object.keys(sent_headers).should.include('authorization');
+        Object.keys(sent_headers).should.containEql('authorization');
         done();
       })
     })
@@ -103,7 +103,7 @@ describe('Basic Auth', function() {
     it('sends Authorization header', function(done) {
       needle.get('localhost:' + port, opts, function(err, resp) {
         var sent_headers = resp.body.headers;
-        Object.keys(sent_headers).should.include('authorization');
+        Object.keys(sent_headers).should.containEql('authorization');
         done();
       })
     })
@@ -121,20 +121,20 @@ describe('Basic Auth', function() {
 
   })
 
-  describe('when username AND password are non empty strings', function() {
+  describe('when username/password are included in URL', function() {
 
     var opts = { username: 'foobar', password: 'jakub', parse: true };
 
     it('sends Authorization header', function(done) {
-      needle.get('localhost:' + port, opts, function(err, resp) {
+      needle.get('foobar:jakub@localhost:' + port, opts, function(err, resp) {
         var sent_headers = resp.body.headers;
-        Object.keys(sent_headers).should.include('authorization');
+        Object.keys(sent_headers).should.containEql('authorization');
         done();
       })
     })
 
     it('Basic Auth only includes both user and password', function(done) {
-      needle.get('localhost:' + port, opts, function(err, resp) {
+      needle.get('foobar:jakub@localhost:' + port, opts, function(err, resp) {
         var sent_headers = resp.body.headers;
         var auth = get_auth(sent_headers['authorization']);
         auth[0].should.equal('foobar');

--- a/test/basic_auth_spec.js
+++ b/test/basic_auth_spec.js
@@ -147,8 +147,7 @@ describe('Basic Auth', function() {
   })
 
   describe('when username/password are included in URL', function() {
-
-    var opts = { username: 'foobar', password: 'jakub', parse: true };
+    var opts = { parse: true };
 
     it('sends Authorization header', function(done) {
       needle.get('foobar:jakub@localhost:' + port, opts, function(err, resp) {

--- a/test/errors_spec.js
+++ b/test/errors_spec.js
@@ -22,7 +22,7 @@ describe('errors', function(){
     it('throws', function(){
       var ex = get_catch(); // null
       should.exist(ex);
-      ex.message.should.include('Cannot call method');
+      ex.message.should.containEql('Cannot call method');
     })
 
   })


### PR DESCRIPTION
* Added basic auth support for URL's with [RFC-1738](http://tools.ietf.org/html/rfc1738#section-3.1) `username:password` syntax.
* Updated unit tests for [Mocha 4.x compatibility](https://github.com/shouldjs/should.js/wiki/Breaking-changes-4.x) (replaced `include` with `containEql`)
* Added unit tests for basic auth in URLs