### PR TITLE
Pass 'response' and 'error' events to the output stream.

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -232,7 +232,7 @@ var Needle = {
 
       var headers = resp.headers;
       debug('Got response', headers);
-      if (timer) clearTimeout(timer);
+      if (timer) timer.clearReq();
 
       // if redirect code is found, send a GET request to that location if enabled via 'follow' option
       if ([301, 302, 303].indexOf(resp.statusCode) != -1 && headers.location) {
@@ -359,26 +359,43 @@ var Needle = {
     }); // end request call
 
     // unless timeout was disabled, set a timeout to abort the request
-    var timerGenerator = function(cb) {
-      if (config.timeout > 0) {
-        return setTimeout(cb, config.timeout);
-      }
-      return null;
+    if (config.timeout > 0) {
+      timer = {
+        setReq: function() {
+          this.reqId = setTimeout(function(){
+            request.abort();
+          }, config.timeout);
+        },
+        setResp: function() {
+          this.respId = setTimeout(function(){
+            out.emit('timeout');
+          }, config.timeout);
+        },
+        clearReq: function() {
+          clearTimeout(this.reqId);
+        },
+        clearResp: function() {
+          clearTimeout(this.respId);
+        },
+        clear: function() {
+          this.clearReq();
+          this.clearResp();
+        }
+      };
     }
 
-    var timer = timerGenerator(function() {
-      request.abort();
-    });
+    if (timer) timer.setReq();
     request.on('error', function(err) {
       debug('Request error', err);
-      if (timer) clearTimeout(timer);
+      if (timer) timer.clear();
       out.emit('error', err);
       done(err || new Error('Unknown error when making request.'));
     });
 
     request.on('response', function(resp) {
-      timerGenerator(function() {
-        out.emit('timeout');
+      if (timer) timer.setResp();
+      resp.on('end', function() {
+        if (timer) timer.clearResp();
       });
       out.emit('response', resp);
     });

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -364,24 +364,30 @@ var Needle = {
     if (config.timeout > 0) {
       timer = {
         setReq: function() {
+          debug('timer: setup require timeout');
           this.reqId = setTimeout(function(){
             out.emit('timeout', 'request');
             request.abort();
           }, config.timeout);
         },
         setResp: function(resp) {
+          debug('timer: setup response timeout');
           this.respId = setTimeout(function(){
             out.emit('timeout', 'response');
             done(new Error('Response timeout'), resp, Buffer.concat(partial_chunks));
+            request.abort();
           }, config.timeout);
         },
         clearReq: function() {
+          debug('timer: clear request timeout');
           clearTimeout(this.reqId);
         },
         clearResp: function() {
+          debug('timer: clear response timeout');
           clearTimeout(this.respId);
         },
         clear: function() {
+          debug('timer: clear both');
           this.clearReq();
           this.clearResp();
         }

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -359,12 +359,16 @@ var Needle = {
     }); // end request call
 
     // unless timeout was disabled, set a timeout to abort the request
-    if (config.timeout > 0) {
-      timer = setTimeout(function() {
-        request.abort();
-      }, config.timeout)
+    var timerGenerator = function(cb) {
+      if (config.timeout > 0) {
+        return setTimeout(cb, config.timeout);
+      }
+      return null;
     }
 
+    var timer = timerGenerator(function() {
+      request.abort();
+    });
     request.on('error', function(err) {
       debug('Request error', err);
       if (timer) clearTimeout(timer);
@@ -373,6 +377,9 @@ var Needle = {
     });
 
     request.on('response', function(resp) {
+      timerGenerator(function() {
+        out.emit('timeout');
+      });
       out.emit('response', resp);
     });
 

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -363,12 +363,13 @@ var Needle = {
       timer = {
         setReq: function() {
           this.reqId = setTimeout(function(){
+            out.emit('timeout', 'request');
             request.abort();
           }, config.timeout);
         },
         setResp: function() {
           this.respId = setTimeout(function(){
-            out.emit('timeout');
+            out.emit('timeout', 'response');
           }, config.timeout);
         },
         clearReq: function() {

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -368,8 +368,12 @@ var Needle = {
     request.on('error', function(err) {
       debug('Request error', err);
       if (timer) clearTimeout(timer);
-
+      out.emit('error', err);
       done(err || new Error('Unknown error when making request.'));
+    });
+
+    request.on('response', function(resp) {
+      out.emit('response', resp);
     });
 
     if (post_data) {

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -213,10 +213,11 @@ var Needle = {
   send_request: function(count, method, uri, config, post_data, out, callback) {
 
     var timer,
-        returned     = 0,
-        self         = this,
-        request_opts = this.get_request_opts(method, uri, config),
-        protocol     = request_opts.protocol == 'https:' ? https : http;
+        returned       = 0,
+        partial_chunks = [],
+        self           = this,
+        request_opts   = this.get_request_opts(method, uri, config),
+        protocol       = request_opts.protocol == 'https:' ? https : http;
 
     var done = function(err, resp, body) {
       if (returned++ > 0) return;
@@ -367,9 +368,10 @@ var Needle = {
             request.abort();
           }, config.timeout);
         },
-        setResp: function() {
+        setResp: function(resp) {
           this.respId = setTimeout(function(){
             out.emit('timeout', 'response');
+            done(new Error('Response timeout'), resp, Buffer.concat(partial_chunks));
           }, config.timeout);
         },
         clearReq: function() {
@@ -389,12 +391,14 @@ var Needle = {
     request.on('error', function(err) {
       debug('Request error', err);
       if (timer) timer.clear();
-      out.emit('error', err);
       done(err || new Error('Unknown error when making request.'));
     });
 
     request.on('response', function(resp) {
-      if (timer) timer.setResp();
+      if (timer) timer.setResp(resp);
+      resp.on('data', function(data) {
+        partial_chunks.push(data);
+      });
       resp.on('end', function() {
         if (timer) timer.clearResp();
       });

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -222,6 +222,7 @@ var Needle = {
     var done = function(err, resp, body) {
       if (returned++ > 0) return;
 
+      if (timer) timer.clear();
       if (callback)
         callback(err, resp, body);
       else
@@ -390,7 +391,6 @@ var Needle = {
     if (timer) timer.setReq();
     request.on('error', function(err) {
       debug('Request error', err);
-      if (timer) timer.clear();
       done(err || new Error('Unknown error when making request.'));
     });
 

--- a/test/stream_spec.js
+++ b/test/stream_spec.js
@@ -77,23 +77,15 @@ describe('stream', function() {
         });
       })
 
-      it('should emit error event and the argument is an Error instance.', function(done) {
-        var stream     = needle.get('localhost:' + (port + 1), {timeout: 100});
-
-        stream.on('error', function (err) {
-          err.should.be.an.instanceOf(Error);
-          done();
-        });
-      })
-
       it('should emit timeout event if request timeout.', function(done) {
         var stream     = needle.get('localhost:' + (port + 1), {timeout: 100});
 
         stream.on('timeout', function (what) {
           what.should.equal('request');
-          done();
         });
-        stream.on('error', function (err) {
+        stream.on('end', function (err) {
+          err.should.be.an.instanceOf(Error);
+          done();
         });
       })
 
@@ -102,6 +94,18 @@ describe('stream', function() {
 
         stream.on('timeout', function (what) {
           what.should.equal('response');
+          done();
+        });
+      })
+
+      it('should emit end event with partial response data if response timeout.', function(done) {
+        var stream     = needle.get('localhost:' + (port + 2), {timeout: 100});
+
+        stream.on('end', function (err, resp, partial) {
+          err.should.be.an.instanceOf(Error);
+          err.message.should.equal('Response timeout');
+          resp.should.be.an.object;
+          partial.toString().should.equal('a');
           done();
         });
       })

--- a/test/stream_spec.js
+++ b/test/stream_spec.js
@@ -75,7 +75,7 @@ describe('stream', function() {
         stream.on('response', function (resp) {
           resp.should.be.an.instanceOf(http.IncomingMessage);
           done();
-        })
+        });
       })
 
       it('should emit error event and the argument is an Error instance.', function(done) {
@@ -84,16 +84,25 @@ describe('stream', function() {
         stream.on('error', function (err) {
           err.should.be.an.instanceOf(Error);
           done();
-        })
+        });
       })
 
-      it('should emit timeout event if the response takes too long.', function(done) {
+      it('should emit timeout event if request timeout.', function(done) {
+        var stream     = needle.get('localhost:' + (port + 1), {timeout: 1});
+
+        stream.on('timeout', function (what) {
+          what.should.equal('request');
+          done();
+        });
+      })
+
+      it('should emit timeout event if response timeout.', function(done) {
         var stream     = needle.get('localhost:' + (port + 2), {timeout: 1});
 
-        stream.on('timeout', function (err) {
-          true.should.be.true;
+        stream.on('timeout', function (what) {
+          what.should.equal('response');
           done();
-        })
+        });
       })
 
       it('should emit a raw buffer if we do not want to parse JSON', function(done) {

--- a/test/stream_spec.js
+++ b/test/stream_spec.js
@@ -16,12 +16,11 @@ describe('stream', function() {
         res.end('{"foo":"bar"}');
       }).listen(port);
       serverTimeout = http.createServer(function(req, res) {
-        setTimeout(function() { res.end(); }, 3);
+        setTimeout(function() { res.end(); }, 300);
       }).listen(port + 1);
       serverTimeoutOnResponse = http.createServer(function(req, res) {
-        res.setHeader('Content-Type', 'application/json');
         res.write('a');
-        setTimeout(function() { res.end('bcde'); }, 3);
+        setTimeout(function() { res.end('bcde'); }, 300);
       }).listen(port + 2);
     });
 
@@ -79,7 +78,7 @@ describe('stream', function() {
       })
 
       it('should emit error event and the argument is an Error instance.', function(done) {
-        var stream     = needle.get('localhost:' + (port + 1), {timeout: 1});
+        var stream     = needle.get('localhost:' + (port + 1), {timeout: 100});
 
         stream.on('error', function (err) {
           err.should.be.an.instanceOf(Error);
@@ -88,16 +87,18 @@ describe('stream', function() {
       })
 
       it('should emit timeout event if request timeout.', function(done) {
-        var stream     = needle.get('localhost:' + (port + 1), {timeout: 1});
+        var stream     = needle.get('localhost:' + (port + 1), {timeout: 100});
 
         stream.on('timeout', function (what) {
           what.should.equal('request');
           done();
         });
+        stream.on('error', function (err) {
+        });
       })
 
       it('should emit timeout event if response timeout.', function(done) {
-        var stream     = needle.get('localhost:' + (port + 2), {timeout: 1});
+        var stream     = needle.get('localhost:' + (port + 2), {timeout: 100});
 
         stream.on('timeout', function (what) {
           what.should.equal('response');


### PR DESCRIPTION
Node.js HTTP(S) module will emit 'response' event if you add a listener on it.

http://nodejs.org/api/http.html#http_event_response
