### PR TITLE
Use debug package for more standard debugging (composable, featureful, e...

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -10,6 +10,7 @@ var fs          = require('fs'),
     https       = require('https'),
     url         = require('url'),
     stream      = require('stream'),
+    debug       = require('debug')('needle'),
     stringify   = require('./querystring').build,
     multipart   = require('./multipart'),
     auth        = require('./auth'),
@@ -20,9 +21,7 @@ var fs          = require('fs'),
 // variabilia
 //////////////////////////////////////////
 
-var version     = JSON.parse(fs.readFileSync(__dirname + '/../package.json').toString()).version,
-    debugging   = !!process.env.DEBUG,
-    debug       = debugging ? console.log : function() { /* noop */ };
+var version     = JSON.parse(fs.readFileSync(__dirname + '/../package.json').toString()).version;
 
 var user_agent  = 'Needle/' + version;
 user_agent     += ' (Node.js ' + process.version + '; ' + process.platform + ' ' + process.arch + ')';
@@ -227,7 +226,7 @@ var Needle = {
         out.emit('end', err, resp, body);
     }
 
-    debug('Making request #' + count, request_opts);
+    debug('Making request #%d', count, request_opts);
     var request = protocol.request(request_opts, function(resp) {
 
       var headers = resp.headers;

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -5,12 +5,18 @@
 // MIT Licensed
 //////////////////////////////////////////
 
+var debug;
+try { 
+  debug = require('debug')('needle');
+} catch(e) {
+  debug = process.env.DEBUG ? console.log : function () { };
+}
+
 var fs          = require('fs'),
     http        = require('http'),
     https       = require('https'),
     url         = require('url'),
     stream      = require('stream'),
-    debug       = require('debug')('needle'),
     stringify   = require('./querystring').build,
     multipart   = require('./multipart'),
     auth        = require('./auth'),

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "url": "https://github.com/tomas/needle.git"
   },
   "dependencies": {
+    "debug": "^2.1.1",
     "iconv-lite": "^0.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
To enable debugging alongside our greater apps, switched to the 'debug' package and used namespace 'needle'. This should be basically a superset of previous behavior.