### PR TITLE
Fix error on string to array conversion

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -5,7 +5,7 @@ var valid_keys = ['domain', 'path', 'expires', 'httponly', 'secure'];
 
 function parse(str, opt) {
 
-  var obj   = {}, 
+  var obj   = {},
       res   = {},
       pairs = str.split(/; */), // matches no whitespace too
       dec   = decodeURIComponent;
@@ -60,10 +60,10 @@ function to_hash(arr, url) {
   return res;
 }
 
-// returns a key/val object from an array of 
+// returns a key/val object from an array of
 exports.read = function(header) {
   var arr = (header instanceof Array) ? header : [header];
-  return to_hash(header.map(function(c) { return parse(c) }));
+  return to_hash(arr.map(function(c) { return parse(c); }));
 }
 
 exports.write = function(obj) {


### PR DESCRIPTION
So you were converting the header variable into an array but not using it, which caused an error on a wrapper I'm building on toy of this library.

I'd recommend a linter, as this error would have been shown right away (`arr` was declared but never used).

A great linter is ESLint, you can get some really great style consistency and avoid obvious typos and errors with it.


Cheers