### PR TITLE
Made automagic http prepending reliable

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -238,8 +238,9 @@ Needle.prototype.start = function() {
       options  = this.options || {};
 
   // if no 'http' is found on URL, prepend it.
-  if (uri.indexOf('http') === -1)
-    uri = 'http://' + uri;
+  if ( ! /^https?:\/\//i.test(uri.trim()) ) {
+  	uri = 'http://' + uri;
+  }
 
   var config = this.setup(uri, options);
 


### PR DESCRIPTION
Hello, old method of 'automagic' prepending was a bit unreliable. Example, if domain starts with http, or has a directory in the path containing 'http', your method wouldn't work. This simple regular expression should do the trick. 