### PR TITLE
Fix variable leak

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -233,7 +233,7 @@ Needle.prototype.start = function() {
       out      = new stream.PassThrough({ objectMode: false }),
       uri      = this.uri,
       data     = this.data,
-      method   = this.method;
+      method   = this.method,
       callback = (typeof this.options == 'function') ? this.options : this.callback,
       options  = this.options || {};
 


### PR DESCRIPTION
One of my modules has needle as a dependency and when I run my tests with lab it prints:
```
The following leaks were detected:options, callback
```
I narrowed it down to this missing comma.