### PR TITLE
Use debug module

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -10,6 +10,7 @@ var fs          = require('fs'),
     https       = require('https'),
     url         = require('url'),
     stream      = require('stream'),
+    debug       = require('debug')('needle'),
     stringify   = require('./querystring').build,
     multipart   = require('./multipart'),
     auth        = require('./auth'),
@@ -20,9 +21,7 @@ var fs          = require('fs'),
 //////////////////////////////////////////
 // variabilia
 
-var version     = JSON.parse(fs.readFileSync(__dirname + '/../package.json').toString()).version,
-    debugging   = !!process.env.DEBUG,
-    debug       = debugging ? console.log : function() { /* noop */ };
+var version     = JSON.parse(fs.readFileSync(__dirname + '/../package.json').toString()).version;
 
 var user_agent  = 'Needle/' + version;
 user_agent     += ' (Node.js ' + process.version + '; ' + process.platform + ' ' + process.arch + ')';

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "url": "https://github.com/tomas/needle.git"
   },
   "dependencies": {
+    "debug": "^2.1.2",
     "iconv-lite": "^0.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
To enable debugging mode, set the environment variable `DEBUG=needle`.

The output will look something like this:
![screen shot 2015-03-11 at 10 42 10](https://cloud.githubusercontent.com/assets/10602/6594690/551ea3d2-c7db-11e4-9698-953e32624d69.png)

The debug module is the defacto debugging output module, hence a lot of other modules use it. Because the Needle module previously just checked for the presense of the DEBUG environment variable it would go into debug mode when ever the user used the DEBUG environment variable to debug any other module - this creates a lot of unwanted noise.

For more information of how to debug using the debug module, check:
https://github.com/visionmedia/debug