### PR TITLE
Added CookieJar for storing all cookies on redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ These options only apply if the `follow_max` (or `follow`) option is higher than
  - `follow_keep_method`      : If enabled, resends the request using the original verb instead of being rewritten to `get` with no data. `false` by default.
  - `follow_if_same_host`     : When true, Needle will only follow redirects that point to the same host as the original request. `false` by default.
  - `follow_if_same_protocol` : When true, Needle will only follow redirects that point to the same protocol as the original request. `false` by default.
+ - `cookie_jar` : When given an object, Needle will store all cookies on redirects.
 
 Overriding Defaults
 -------------------

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -16,7 +16,8 @@ var fs          = require('fs'),
     auth        = require('./auth'),
     cookies     = require('./cookies'),
     parsers     = require('./parsers'),
-    decoder     = require('./decoder');
+    decoder     = require('./decoder'),
+    extend = require('util')._extend;
 
 //////////////////////////////////////////
 // variabilia
@@ -27,6 +28,8 @@ var user_agent  = 'Needle/' + version;
 user_agent     += ' (Node.js ' + process.version + '; ' + process.platform + ' ' + process.arch + ')';
 
 var tls_options = 'agent pfx key passphrase cert ca ciphers rejectUnauthorized secureProtocol';
+
+var cookieJar = {};
 
 //////////////////////////////////////////
 // decompressors for gzip/deflate bodies
@@ -66,6 +69,7 @@ var defaults = {
   parse_response          : true,
   decode_response         : true,
   follow_set_cookies      : false,
+  follow_set_all_cookies  : false,
   follow_set_referer      : false,
   follow_keep_method      : false,
   follow_if_same_host     : false,
@@ -397,6 +401,11 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
         if (config.follow_set_cookies && resp.cookies)
           config.headers['Cookie'] = cookies.write(resp.cookies);
+
+        if (config.follow_set_all_cookies && resp.cookies){
+          cookieJar = extend(cookieJar, resp.cookies);
+          config.headers['Cookie'] = cookies.write(cookieJar);
+        }
 
         if (config.follow_set_referer)
           config.headers['Referer'] = uri;

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -57,7 +57,6 @@ var defaults = {
   // data
   boundary                : '--------------------NODENEEDLEHTTPCLIENT',
   encoding                : 'utf8',
-  cookie_jar              : {},
   parse                   : 'all', // same as true. valid options: 'json', 'xml' or false/null
 
   // headers
@@ -198,8 +197,8 @@ Needle.prototype.setup = function(uri, options) {
   if (options.cookies)
     config.headers['Cookie'] = cookies.write(options.cookies);
 
-  if (options.cookie_jar || defaults.cookie_jar)
-    config.cookie_jar = options.cookie_jar || defaults.cookie_jar;
+  if (typeof options.cookie_jar !== 'undefined')
+    config.cookie_jar = options.cookie_jar;
 
   // now that all our headers are set, overwrite them if instructed.
   for (var h in options.headers)
@@ -416,6 +415,10 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
     if (headers['set-cookie']) {
       resp.cookies = cookies.read(headers['set-cookie']);
+      if(typeof config.cookie_jar !== 'undefined'){
+        config.cookie_jar = extend(config.cookie_jar, resp.cookies);
+        config.headers['Cookie'] = cookies.write(config.cookie_jar);
+      }
       debug('Got cookies', resp.cookies);
     }
 
@@ -434,7 +437,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
         if (config.follow_set_cookies && resp.cookies){
           config.headers['Cookie'] = cookies.write(resp.cookies);
-        } else if (config.cookie_jar && resp.cookies){
+        } else if (typeof config.cookie_jar !== 'undefined' && resp.cookies){
           config.cookie_jar = extend(config.cookie_jar, resp.cookies);
           config.headers['Cookie'] = cookies.write(config.cookie_jar);
         }

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -29,8 +29,6 @@ user_agent     += ' (Node.js ' + process.version + '; ' + process.platform + ' '
 
 var tls_options = 'agent pfx key passphrase cert ca ciphers rejectUnauthorized secureProtocol';
 
-var cookieJar = {};
-
 //////////////////////////////////////////
 // decompressors for gzip/deflate bodies
 
@@ -54,6 +52,7 @@ var defaults = {
   // data
   boundary                : '--------------------NODENEEDLEHTTPCLIENT',
   encoding                : 'utf8',
+  cookie_jar              : {},
 
   // headers
   accept                  : '*/*',
@@ -69,7 +68,6 @@ var defaults = {
   parse_response          : true,
   decode_response         : true,
   follow_set_cookies      : false,
-  follow_set_all_cookies  : false,
   follow_set_referer      : false,
   follow_keep_method      : false,
   follow_if_same_host     : false,
@@ -190,6 +188,9 @@ Needle.prototype.setup = function(uri, options) {
 
   if (options.cookies)
     config.headers['Cookie'] = cookies.write(options.cookies);
+
+  if (options.cookie_jar || defaults.cookie_jar)
+    config.cookie_jar = options.cookie_jar || defaults.cookie_jar;
 
   // now that all our headers are set, overwrite them if instructed.
   for (var h in options.headers)
@@ -399,12 +400,11 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
           delete config.headers['Content-Length']; // in case the original was a multipart POST request.
         }
 
-        if (config.follow_set_cookies && resp.cookies)
+        if (config.follow_set_cookies && resp.cookies){
           config.headers['Cookie'] = cookies.write(resp.cookies);
-
-        if (config.follow_set_all_cookies && resp.cookies){
-          cookieJar = extend(cookieJar, resp.cookies);
-          config.headers['Cookie'] = cookies.write(cookieJar);
+        } else if (config.cookie_jar && resp.cookies){
+          config.cookie_jar = extend(config.cookie_jar, resp.cookies);
+          config.headers['Cookie'] = cookies.write(config.cookie_jar);
         }
 
         if (config.follow_set_referer)
@@ -559,8 +559,6 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 // exports
 
 exports.version = version;
-
-exports.cookies = cookieJar;
 
 exports.defaults = function(obj) {
   for (var key in obj) {

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -560,6 +560,8 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
 exports.version = version;
 
+exports.cookies = cookieJar;
+
 exports.defaults = function(obj) {
   for (var key in obj) {
     var target_key = aliased.options[key] || key;

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -16,8 +16,7 @@ var fs          = require('fs'),
     auth        = require('./auth'),
     cookies     = require('./cookies'),
     parsers     = require('./parsers'),
-    decoder     = require('./decoder'),
-    extend = require('util')._extend;
+    decoder     = require('./decoder');
 
 //////////////////////////////////////////
 // variabilia
@@ -41,7 +40,7 @@ var decompressors = {};
 
 try {
 
-  var zlib = require('zlib')
+  var zlib = require('zlib');
 
   decompressors['x-deflate'] = zlib.Inflate;
   decompressors['deflate']   = zlib.Inflate;
@@ -76,7 +75,7 @@ var defaults = {
   follow_keep_method      : false,
   follow_if_same_host     : false,
   follow_if_same_protocol : false
-}
+};
 
 var aliased = {
   options: {
@@ -86,7 +85,7 @@ var aliased = {
     follow  : 'follow_max'
   },
   inverted: {}
-}
+};
 
 // only once, invert aliased keys so we can get passed options.
 Object.keys(aliased.options).map(function(k) {
@@ -203,9 +202,6 @@ Needle.prototype.setup = function(uri, options) {
   if (options.cookies)
     config.headers['Cookie'] = cookies.write(options.cookies);
 
-  if (typeof options.cookie_jar !== 'undefined')
-    config.cookie_jar = options.cookie_jar;
-
   // now that all our headers are set, overwrite them if instructed.
   for (var h in options.headers)
     config.headers[h] = options.headers[h];
@@ -275,7 +271,7 @@ Needle.prototype.start = function() {
 
         config.headers['content-type']   = 'multipart/form-data; boundary=' + boundary;
         config.headers['content-length'] = parts.length;
-        self.send_request(1, method, uri, config, parts, out, callback);
+        self.send_request(1, method, uri, config, parts, out, null, callback);
       });
 
       return out; // stream
@@ -320,7 +316,7 @@ Needle.prototype.start = function() {
       config.headers['accept'] = 'application/json';
   }
 
-  return this.send_request(1, method, uri, config, body, out, callback);
+  return this.send_request(1, method, uri, config, body, out, null, callback);
 }
 
 Needle.prototype.get_request_opts = function(method, uri, config) {
@@ -371,7 +367,7 @@ Needle.prototype.should_follow = function(location, config, original) {
   return true;
 }
 
-Needle.prototype.send_request = function(count, method, uri, config, post_data, out, callback) {
+Needle.prototype.send_request = function(count, method, uri, config, post_data, out, redirect_cookies, callback) {
 
   var timer,
       returned     = 0,
@@ -423,10 +419,10 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     set_timeout(config.read_timeout);
 
     if (headers['set-cookie'] && config.parse_cookies) {
-      resp.cookies = cookies.read(headers['set-cookie']);
-      if(typeof config.cookie_jar !== 'undefined'){
-        config.cookie_jar = extend(config.cookie_jar, resp.cookies);
-        config.headers['Cookie'] = cookies.write(config.cookie_jar);
+      if (redirect_cookies !== null) {
+        resp.cookies = Object.assign(redirect_cookies, cookies.read(headers['set-cookie']));  
+      } else {
+        resp.cookies = cookies.read(headers['set-cookie']);
       }
       debug('Got cookies', resp.cookies);
     }
@@ -444,11 +440,8 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
           delete config.headers['content-length']; // in case the original was a multipart POST request.
         }
 
-        if (config.follow_set_cookies && resp.cookies){
-          config.headers['Cookie'] = cookies.write(resp.cookies);
-        } else if (typeof config.cookie_jar !== 'undefined' && resp.cookies){
-          config.cookie_jar = extend(config.cookie_jar, resp.cookies);
-          config.headers['Cookie'] = cookies.write(config.cookie_jar);
+        if (config.follow_set_cookies && resp.cookies) {
+          config.headers['Cookie'] = cookies.write(Object.assign(resp.cookies, cookies.read(headers['set-cookie'])));
         }
 
         if (config.follow_set_referer)
@@ -457,7 +450,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
         config.headers['host'] = null; // clear previous Host header to avoid conflicts.
 
         debug('Redirecting to ' + url.resolve(uri, headers.location));
-        return self.send_request(++count, method, url.resolve(uri, headers.location), config, post_data, out, callback);
+        return self.send_request(++count, method, url.resolve(uri, headers.location), config, post_data, out, cookies.read(headers['set-cookie']), callback);
       } else if (config.follow_max > 0) {
         return done(new Error('Max redirects reached. Possible loop in: ' + headers.location));
       }
@@ -470,7 +463,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
         if (auth_header) {
           config.headers['authorization'] = auth_header;
-          return self.send_request(count, method, uri, config, post_data, out, callback);
+          return self.send_request(count, method, uri, config, post_data, out, null, callback);
         }
       }
     }


### PR DESCRIPTION
Hi, I love needle which simplifies http requests.
I needed to store all the cookies for future request to the same origin, but needle only stores the latest cookie from the last redirect.

I thought someone else might need this feature so I created a pull request.
I've added a global variable to store all the cookies site sets on redirects and requests with cookies saved in the global `cookieJar`. And also, I have added a config key as `follow_set_all_cookies` defaults to `false`. Also, added `exports.cookies` for future needle requests.
