### PR TITLE
resolve path to package.json

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -21,7 +21,7 @@ var fs          = require('fs'),
 //////////////////////////////////////////
 // variabilia
 
-var version     = JSON.parse(fs.readFileSync(__dirname + '/../package.json').toString()).version;
+var version     = JSON.parse(fs.readFileSync(require("path").resolve(__dirname + '/../package.json')).toString()).version;
 
 var user_agent  = 'Needle/' + version;
 user_agent     += ' (Node.js ' + process.version + '; ' + process.platform + ' ' + process.arch + ')';


### PR DESCRIPTION
Otherwise we have an issue finding the file in some special circumstances - e.g. Electron + ASAR + Windows.

Electron (formerly atom-shell) has an option to pack your entire app in an archive, and read it from there. In this case, under Windows, paths with ".." don't work.

I think this is ultimately an issue in Electron, but depending on ".." is a pretty platform-specific approach.
I submitted an issue on their Github: https://github.com/atom/electron/issues/1982

Meanwhile, please consider merging this because it results in a cleaner lookup.