### PR TITLE
[feature] retry request on error

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -62,6 +62,8 @@ var defaults = {
   open_timeout            : 10000,
   read_timeout            : 0,
   follow_max              : 0,
+  retry_request_max   : 5,
+  retry_request_wait  : 3000, // how much to wait in ms to retry the request
 
   // booleans
   decode_response         : true,
@@ -69,7 +71,11 @@ var defaults = {
   follow_set_referer      : false,
   follow_keep_method      : false,
   follow_if_same_host     : false,
-  follow_if_same_protocol : false
+  follow_if_same_protocol : false,
+  retry_request           : false, // retry request if some error happens (ECONNRESET)
+
+  // lists
+  retry_request_on_error_code : ['ECONNRESET']
 }
 
 var aliased = {
@@ -163,6 +169,10 @@ Needle.prototype.setup = function(uri, options) {
 
   keys_by_type(Number).forEach(function(key) {
     config[key] = check_value('number', key);
+  })
+
+  keys_by_type(Array).forEach(function(key) {
+    config[key] = check_value('array', key);
   })
 
   // populate http_opts with given TLS options
@@ -343,6 +353,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
   var timer,
       returned     = 0,
+      countRetries = 1,
       self         = this,
       request_opts = this.get_request_opts(method, uri, config),
       protocol     = request_opts.protocol == 'https:' ? https : http;
@@ -369,200 +380,231 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     timer = setTimeout(function() { request.abort() }, milisecs);
   }
 
-  debug('Making request #' + count, request_opts);
-  var request = protocol.request(request_opts, function(resp) {
+  function create_request(){
+    var request = protocol.request(request_opts, function(resp) {
+      var headers = resp.headers;
+      debug('Got response', resp.statusCode, headers);
 
-    var headers = resp.headers;
-    debug('Got response', resp.statusCode, headers);
+      // clear open timeout, and set a read timeout.
+      if (timer) clearTimeout(timer);
+      set_timeout(config.read_timeout);
 
-    // clear open timeout, and set a read timeout.
-    if (timer) clearTimeout(timer);
-    set_timeout(config.read_timeout);
-
-    if (headers['set-cookie']) {
-      resp.cookies = cookies.read(headers['set-cookie']);
-      debug('Got cookies', resp.cookies);
-    }
-
-    // if redirect code is found, send a GET request to that location if enabled via 'follow' option
-    if ([301, 302, 303].indexOf(resp.statusCode) !== -1 && self.should_follow(headers.location, config, uri)) {
-
-      if (count <= config.follow_max) {
-        out.emit('redirect', headers.location);
-
-        // unless follow_keep_method was set to true, rewrite the request to GET before continuing
-        if (!config.follow_keep_method) {
-          method    = 'GET';
-          post_data = null;
-          delete config.headers['Content-Length']; // in case the original was a multipart POST request.
-        }
-
-        if (config.follow_set_cookies && resp.cookies)
-          config.headers['Cookie'] = cookies.write(resp.cookies);
-
-        if (config.follow_set_referer)
-          config.headers['Referer'] = uri;
-
-        config.headers['Host'] = null; // clear previous Host header to avoid conflicts.
-
-        debug('Redirecting to ' + url.resolve(uri, headers.location));
-        return self.send_request(++count, method, url.resolve(uri, headers.location), config, post_data, out, callback);
-      } else if (config.follow_max > 0) {
-        return done(new Error('Max redirects reached. Possible loop in: ' + headers.location));
-      }
-    }
-
-    // if authentication is requested and credentials were not passed, resend request if we have user/pass
-    if (resp.statusCode == 401 && headers['www-authenticate'] && config.credentials) {
-      if (!config.headers['Authorization']) { // only if authentication hasn't been sent
-        var auth_header = auth.header(headers['www-authenticate'], config.credentials, request_opts);
-
-        if (auth_header) {
-          config.headers['Authorization'] = auth_header;
-          return self.send_request(count, method, uri, config, post_data, out, callback);
-        }
-      }
-    }
-
-    // ok so we got a valid (non-redirect & authorized) response. notify the stream guys.
-    out.emit('headers', headers);
-
-    var pipeline      = [],
-        mime          = parse_content_type(headers['content-type']),
-        text_response = mime.type && mime.type.indexOf('text/') != -1;
-
-    // To start, if our body is compressed and we're able to inflate it, do it.
-    if (headers['content-encoding'] && decompressors[headers['content-encoding']]) {
-      pipeline.push(decompressors[headers['content-encoding']]());
-    }
-
-    // If parse is enabled and we have a parser for it, then go for it.
-    if (config.parser && parsers[mime.type]) {
-
-      // If a specific parser was requested, make sure we don't parse other types.
-      var parser_name = config.parser.toString().toLowerCase();
-      if (['xml', 'json'].indexOf(parser_name) == -1 || parsers[mime.type].name == parser_name) {
-
-        // OK, so either we're parsing all content types or the one requested matches.
-        out.parser = parsers[mime.type].name;
-        pipeline.push(parsers[mime.type].fn());
-
-        // Set objectMode on out stream to improve performance.
-        out._writableState.objectMode = true;
-        out._readableState.objectMode = true;
+      if (headers['set-cookie']) {
+        resp.cookies = cookies.read(headers['set-cookie']);
+        debug('Got cookies', resp.cookies);
       }
 
-    // If we're not parsing, and unless decoding was disabled, we'll try
-    // decoding non UTF-8 bodies to UTF-8, using the iconv-lite library.
-    } else if (text_response && config.decode_response
-      && mime.charset && !mime.charset.match(/utf-?8$/i)) {
-        pipeline.push(decoder(mime.charset));
-    }
+      // if redirect code is found, send a GET request to that location if enabled via 'follow' option
+      if ([301, 302, 303].indexOf(resp.statusCode) !== -1 && self.should_follow(headers.location, config, uri)) {
 
-    // And `out` is the stream we finally push the decoded/parsed output to.
-    pipeline.push(out);
+        if (count <= config.follow_max) {
+          out.emit('redirect', headers.location);
 
-    // Now, release the kraken!
-    var tmp = resp;
-    while (pipeline.length) {
-      tmp = tmp.pipe(pipeline.shift());
-    }
+          // unless follow_keep_method was set to true, rewrite the request to GET before continuing
+          if (!config.follow_keep_method) {
+            method    = 'GET';
+            post_data = null;
+            delete config.headers['Content-Length']; // in case the original was a multipart POST request.
+          }
 
-    // If the user has requested and output file, pipe the output stream to it.
-    // In stream mode, we will still get the response stream to play with.
-    if (config.output && resp.statusCode == 200) {
+          if (config.follow_set_cookies && resp.cookies)
+            config.headers['Cookie'] = cookies.write(resp.cookies);
 
-      // for some reason, simply piping resp to the writable streams doesn't
-      // work all the time (stream gets cut in the middle with no warning).
-      // so we'll manually need to do the readable/write(chunk) trick.
-      var file = fs.createWriteStream(config.output);
-      file.on('error', had_error);
+          if (config.follow_set_referer)
+            config.headers['Referer'] = uri;
 
-      out.on('readable', function() {
-        var chunk;
-        while (chunk = this.read()) {
-          if (file.writable) file.write(chunk);
+          config.headers['Host'] = null; // clear previous Host header to avoid conflicts.
+
+          debug('Redirecting to ' + url.resolve(uri, headers.location));
+          return self.send_request(++count, method, url.resolve(uri, headers.location), config, post_data, out, callback);
+        } else if (config.follow_max > 0) {
+          return done(new Error('Max redirects reached. Possible loop in: ' + headers.location));
         }
-      })
+      }
 
-    }
+      // if authentication is requested and credentials were not passed, resend request if we have user/pass
+      if (resp.statusCode == 401 && headers['www-authenticate'] && config.credentials) {
+        if (!config.headers['Authorization']) { // only if authentication hasn't been sent
+          var auth_header = auth.header(headers['www-authenticate'], config.credentials, request_opts);
 
-    // Only aggregate the full body if a callback was requested.
-    if (callback) {
-      resp.raw   = [];
-      resp.body  = [];
-      resp.bytes = 0;
-
-      // Count the amount of (raw) bytes passed using a PassThrough stream.
-      var clean_pipe = new stream.PassThrough();
-      resp.pipe(clean_pipe);
-
-      clean_pipe.on('readable', function() {
-        var chunk;
-        while (chunk = this.read()) {
-          resp.bytes += chunk.length;
-          resp.raw.push(chunk);
-        }
-      })
-
-      // Listen on the 'readable' event to aggregate the chunks.
-      out.on('readable', function() {
-        var chunk;
-        while ((chunk = this.read()) !== null) {
-          // We're either pushing buffers or objects, never strings.
-          if (typeof chunk == 'string') chunk = new Buffer(chunk);
-
-          // Push all chunks to resp.body. We'll bind them in resp.end().
-          resp.body.push(chunk);
-        }
-      })
-
-      // And set the .body property once all data is in.
-      out.on('end', function() {
-        // we may want access to the raw data, so keep a reference.
-        resp.raw = Buffer.concat(resp.raw);
-
-        // if parse was successful, we should have an array with one object
-        if (resp.body[0] !== undefined && !Buffer.isBuffer(resp.body[0])) {
-
-          // that's our body right there.
-          resp.body = resp.body[0];
-
-          // set the parser property on our response. we may want to check.
-          if (out.parser) resp.parser = out.parser;
-
-        } else { // we got one or several buffers. string or binary.
-          resp.body = Buffer.concat(resp.body);
-
-          // if we're here and parsed is true, it means we tried to but it didn't work.
-          // so given that we got a text response, let's stringify it.
-          if (text_response || out.parser) {
-            resp.body = resp.body.toString();
+          if (auth_header) {
+            config.headers['Authorization'] = auth_header;
+            return self.send_request(count, method, uri, config, post_data, out, callback);
           }
         }
+      }
 
-        // time to call back, junior.
-        done(null, resp, resp.body);
-      });
+      // ok so we got a valid (non-redirect & authorized) response. notify the stream guys.
+      out.emit('headers', headers);
 
-    }
+      var pipeline      = [],
+          mime          = parse_content_type(headers['content-type']),
+          text_response = mime.type && mime.type.indexOf('text/') != -1;
 
-  }); // end request call
+      // To start, if our body is compressed and we're able to inflate it, do it.
+      if (headers['content-encoding'] && decompressors[headers['content-encoding']]) {
+        pipeline.push(decompressors[headers['content-encoding']]());
+      }
 
-  // unless timeout was disabled, set a timeout to abort the request
-  set_timeout(config.open_timeout);
-  request.on('error', had_error);
+      // If parse is enabled and we have a parser for it, then go for it.
+      if (config.parser && parsers[mime.type]) {
 
-  if (post_data) {
-    if (is_stream(post_data)) {
-      post_data.pipe(request);
+        // If a specific parser was requested, make sure we don't parse other types.
+        var parser_name = config.parser.toString().toLowerCase();
+        if (['xml', 'json'].indexOf(parser_name) == -1 || parsers[mime.type].name == parser_name) {
+
+          // OK, so either we're parsing all content types or the one requested matches.
+          out.parser = parsers[mime.type].name;
+          pipeline.push(parsers[mime.type].fn());
+
+          // Set objectMode on out stream to improve performance.
+          out._writableState.objectMode = true;
+          out._readableState.objectMode = true;
+        }
+
+      // If we're not parsing, and unless decoding was disabled, we'll try
+      // decoding non UTF-8 bodies to UTF-8, using the iconv-lite library.
+      } else if (text_response && config.decode_response
+        && mime.charset && !mime.charset.match(/utf-?8$/i)) {
+          pipeline.push(decoder(mime.charset));
+      }
+
+      // And `out` is the stream we finally push the decoded/parsed output to.
+      pipeline.push(out);
+
+      // Now, release the kraken!
+      var tmp = resp;
+      while (pipeline.length) {
+        tmp = tmp.pipe(pipeline.shift());
+      }
+
+      // If the user has requested and output file, pipe the output stream to it.
+      // In stream mode, we will still get the response stream to play with.
+      if (config.output && resp.statusCode == 200) {
+
+        // for some reason, simply piping resp to the writable streams doesn't
+        // work all the time (stream gets cut in the middle with no warning).
+        // so we'll manually need to do the readable/write(chunk) trick.
+        var file = fs.createWriteStream(config.output);
+        file.on('error', had_error);
+
+        out.on('readable', function() {
+          var chunk;
+          while (chunk = this.read()) {
+            if (file.writable) file.write(chunk);
+          }
+        })
+      }
+
+      // Only aggregate the full body if a callback was requested.
+      if (callback) {
+        resp.raw   = [];
+        resp.body  = [];
+        resp.bytes = 0;
+
+        // Count the amount of (raw) bytes passed using a PassThrough stream.
+        var clean_pipe = new stream.PassThrough();
+        resp.pipe(clean_pipe);
+
+        clean_pipe.on('readable', function() {
+          var chunk;
+          while (chunk = this.read()) {
+            resp.bytes += chunk.length;
+            resp.raw.push(chunk);
+          }
+        })
+
+        // Listen on the 'readable' event to aggregate the chunks.
+        out.on('readable', function() {
+          var chunk;
+          while ((chunk = this.read()) !== null) {
+            // We're either pushing buffers or objects, never strings.
+            if (typeof chunk == 'string') chunk = new Buffer(chunk);
+
+            // Push all chunks to resp.body. We'll bind them in resp.end().
+            resp.body.push(chunk);
+          }
+        })
+
+        // And set the .body property once all data is in.
+        out.on('end', function() {
+          // we may want access to the raw data, so keep a reference.
+          resp.raw = Buffer.concat(resp.raw);
+
+          // if parse was successful, we should have an array with one object
+          if (resp.body[0] !== undefined && !Buffer.isBuffer(resp.body[0])) {
+
+            // that's our body right there.
+            resp.body = resp.body[0];
+
+            // set the parser property on our response. we may want to check.
+            if (out.parser) resp.parser = out.parser;
+
+          } else { // we got one or several buffers. string or binary.
+            resp.body = Buffer.concat(resp.body);
+
+            // if we're here and parsed is true, it means we tried to but it didn't work.
+            // so given that we got a text response, let's stringify it.
+            if (text_response || out.parser) {
+              resp.body = resp.body.toString();
+            }
+          }
+
+          // time to call back, junior.
+          done(null, resp, resp.body);
+        });
+
+      }
+
+    });
+
+    // unless timeout was disabled, set a timeout to abort the request
+    set_timeout(config.open_timeout);
+
+    request.on('error', function(err){
+      if(config.retry_request && err && config.retry_request_on_error_code.indexOf(err.code) !== -1){
+        if(countRetries < config.retry_request_max){
+          var retry = function(){
+            out.emit('retry_request', out.request);
+            out.request = create_request(); // replace the errored request
+            countRetries++;
+          }
+
+          if(!config.retry_request_wait){
+            retry(); // retry immediately!
+          }else{
+            setTimeout(retry, config.retry_request_wait);
+          }
+        }else{
+          var new_err = new Error('Max request attempts reached. Giving up with error: ' + err.code)
+
+          if(err.code)
+            new_err.code = err.code;
+
+          had_error(new_err);
+        }
+      }else{
+        had_error(err);
+      }
+    });
+
+    if (post_data) {
+      if (is_stream(post_data)) {
+        post_data.pipe(request);
+      } else {
+        request.write(post_data, config.encoding);
+        request.end();
+      }
     } else {
-      request.write(post_data, config.encoding);
       request.end();
     }
-  } else {
-    request.end();
-  }
+
+    return request;
+  } // end request call
+
+  debug('Making request #' + count, request_opts);
+
+  var request = create_request();
 
   out.request = request;
   return out;

--- a/test/retry_request_spec.js
+++ b/test/retry_request_spec.js
@@ -1,0 +1,79 @@
+var should  = require('should'),
+    fs      = require('fs'),
+    needle  = require('./../');
+
+var port1 = 8888, port2 = 8889;
+
+describe('retry request', function() {
+  var spies   = {},
+      servers = [];
+
+  // open 2 servers:
+  // one that that receives a connection and hangup immediately for every request
+  // a second that hangs up the first connection and them succeeds in the second
+  before(function(done) {
+    // server 1
+    var server = require('http').createServer(function(req, res){
+      res.socket.destroy();
+    });
+    server.listen(port1, function(){
+    });
+
+    servers.push(server);
+
+    // server 2
+    var connCount = 0;
+    server = require('http').createServer(function(req, res){
+      connCount++;
+      if(connCount > 1){
+        res.end('ok');
+      }else{
+        res.socket.destroy();
+      }
+    });
+    server.listen(port2, function(){
+    });
+    servers.push(server);
+    done();
+  });
+
+  after(function(done){
+    servers[0].close(function(){
+      servers[1].close(done);
+    });
+  })
+
+  describe('when receives a ECONNRESET error', function(){
+    it('should retry connection five times and then reach connection limit', function(done){
+
+      function retry_five_times(err){
+        err.code.should.eql('ECONNRESET');
+        numberOfTries.should.eql(5);
+        done();
+      }
+
+      var obj = needle.get('http://127.0.0.1:' + port1, { retry_request: true, retry_request_wait: 100 }, retry_five_times),
+          numberOfTries = 1;
+
+      obj.on('retry_request', function(){
+        numberOfTries++;
+      });
+    })
+
+    it('should retry connection one time and then receive some response', function(done){
+
+      function retry_and_succeeds(err, res, body){
+        numberOfTries.should.eql(2);
+        body.toString().should.eql('ok');
+        done();
+      }
+
+      var obj = needle.get('http://127.0.0.1:' + port2, { retry_request: true, retry_request_wait: 100 }, retry_and_succeeds),
+          numberOfTries = 1;
+
+      obj.on('retry_request', function(){
+        numberOfTries++;
+      });
+    })
+  });
+});


### PR DESCRIPTION
In one of my projects I needed to crawl a large number of web pages, so "socket hangup" errors were very common.

With this pull request it's possible to retry a given request if a some error happens. The new options added are:

```javascript
var opts = {
  retry_request           : true, // (default: false) if should retry request if some ECONNRESET error happens
  retry_request_max   : 5, // max attempts to be made
  retry_request_wait  : 3000, // how much to wait in ms to retry the request
  retry_request_on_error_code : ['ECONNRESET'] // the errors that should trigger a retry, ECONNRESET only by default
}
needle.get('http://google.com', opts);
```