### PR TITLE
Allow needle to run with browserify

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -21,7 +21,7 @@ var fs          = require('fs'),
 //////////////////////////////////////////
 // variabilia
 
-var version     = JSON.parse(fs.readFileSync(__dirname + '/../package.json').toString()).version;
+var version     = require('../package.json').version;
 
 var user_agent  = 'Needle/' + version;
 user_agent     += ' (Node.js ' + process.version + '; ' + process.platform + ' ' + process.arch + ')';


### PR DESCRIPTION
Using `require` is more succinct and allows needle to be more readily packaged with browserify.