### PR TITLE
Makes checkServerIdentity a valid tls_options.

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -26,7 +26,7 @@ var version     = require('../package.json').version;
 var user_agent  = 'Needle/' + version;
 user_agent     += ' (Node.js ' + process.version + '; ' + process.platform + ' ' + process.arch + ')';
 
-var tls_options = 'agent pfx key passphrase cert ca ciphers rejectUnauthorized secureProtocol';
+var tls_options = 'agent pfx key passphrase cert ca ciphers rejectUnauthorized secureProtocol checkServerIdentity';
 
 // older versions of node (< 0.11.4) prevent the runtime from exiting
 // because of connections in keep-alive state. so if this is the case


### PR DESCRIPTION
This is useful for testing HTTPS access to a self-signed cert server.