### PR TITLE
Disable cookie parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Response options
  - `decode_response` : (or `decode`) Whether to decode the text responses to UTF-8, if Content-Type header shows a different charset. Defaults to `true`.
  - `parse_response`  : (or `parse`) Whether to parse XML or JSON response bodies automagically. Defaults to `true`. You can also set this to 'xml' or 'json' in which case Needle will *only* parse the response if the content type matches.
  - `output`          : Dump response output to file. This occurs after parsing and charset decoding is done.
+ - `parse_cookies`   : Whether to parse response’s `Set-Cookie` header. Defaults to `true`. If parsed, cookies are set on `resp.cookies`.
 
 Note: To stay light on dependencies, Needle doesn't include the `xml2js` module used for XML parsing. To enable it, simply do `npm install xml2js`.
 

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -37,7 +37,7 @@ function encodeCookieComponent(str) {
   return str.toString().replace(EXCLUDED_CHARS, encodeURIComponent);
 }
 
-// Parses a set-cookie-string based on the standard definded in RFC6265 S4.1.1.
+// Parses a set-cookie-string based on the standard defined in RFC6265 S4.1.1.
 function parseSetCookieString(str) {
   str = cleanCookieString(str);
   str = getFirstPair(str);

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -69,6 +69,7 @@ var defaults = {
 
   // booleans
   decode_response         : true,
+  parse_cookies           : true,
   follow_set_cookies      : false,
   follow_set_referer      : false,
   follow_keep_method      : false,
@@ -409,7 +410,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     if (timer) clearTimeout(timer);
     set_timeout(config.read_timeout);
 
-    if (headers['set-cookie']) {
+    if (headers['set-cookie'] && config.parse_cookies) {
       resp.cookies = cookies.read(headers['set-cookie']);
       debug('Got cookies', resp.cookies);
     }

--- a/test/cookies_spec.js
+++ b/test/cookies_spec.js
@@ -137,7 +137,7 @@ describe('cookies', function() {
     });
   });
 
-  describe('if resquest contains cookie header', function() {
+  describe('if request contains cookie header', function() {
     var opts = {
       cookies: {}
     };

--- a/test/cookies_spec.js
+++ b/test/cookies_spec.js
@@ -125,6 +125,16 @@ describe('cookies', function() {
       });
       describe('and follow_set_cookies is true', function() {});
     });
+
+    describe('with parse_cookies = false', function() {
+      it('does not parse them', function(done) {
+        needle.get(
+          TEST_HOST + ':' + ALL_COOKIES_TEST_PORT, { parse_cookies: false }, function(error, response) {
+            assert(!response.cookies);
+            done();
+          });
+      });
+    });
   });
 
   describe('if resquest contains cookie header', function() {


### PR DESCRIPTION
refs #151 

New option `parse_cookies` to enable/disable parsing of response’s `Set-Cookie` header.
Default value is `true` to keep current behavior.
If `false`, `Set-Cookie` header is not parsed and `resp.cookies` is not set.