### PR TITLE
Fixing issue #161: EventEmitter memory leak when sockets are heavily reused

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -372,7 +372,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
     if (timer) clearTimeout(timer);
     request.removeListener('error', had_error);
-    request.socket.removeListener('end', on_socket_end);
+    request.socket.removeListener('end', request.socket.on_socket_end);
 
     if (callback)
       return callback(err, resp, body);
@@ -589,7 +589,8 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
   // handle socket 'end' event to ensure we don't get delayed EPIPE errors.
   request.once('socket', function(socket) {
-    socket.on('end', on_socket_end.bind(socket));
+    socket.on_socket_end = on_socket_end;
+    socket.on('end', socket.on_socket_end);
   })
 
   if (post_data) {

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -291,7 +291,7 @@ Needle.prototype.start = function() {
 
   }
 
-  if (body) { 
+  if (body) {
     // unless we have a stream or set a querystring, set the content length.
     if (body.length) config.headers['Content-Length'] = body.length;
 
@@ -372,7 +372,6 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
     if (timer) clearTimeout(timer);
     request.removeListener('error', had_error);
-    request.socket.removeListener('end', request.socket.on_socket_end);
 
     if (callback)
       return callback(err, resp, body);
@@ -391,9 +390,9 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
   }
 
   // handle errors on the underlying socket, that may be closed while writing
-  // for an example case, see test/long_string_spec.js. we make sure this 
+  // for an example case, see test/long_string_spec.js. we make sure this
   // scenario ocurred by verifying the socket's writable & destroyed states.
-  function on_socket_end() { 
+  function on_socket_end() {
     if (!this.writable && this.destroyed === false) {
       this.destroy();
       had_error(new Error('Remote end closed socket abruptly.'))
@@ -589,8 +588,10 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
   // handle socket 'end' event to ensure we don't get delayed EPIPE errors.
   request.once('socket', function(socket) {
-    socket.on_socket_end = on_socket_end;
-    socket.on('end', socket.on_socket_end);
+    if (!socket.on_socket_end) {
+      socket.on_socket_end = on_socket_end;
+      socket.on('end', socket.on_socket_end);
+    }
   })
 
   if (post_data) {

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -589,7 +589,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
   // handle socket 'end' event to ensure we don't get delayed EPIPE errors.
   request.once('socket', function(socket) {
-    socket.once('end', on_socket_end.bind(socket));
+    socket.on('end', on_socket_end.bind(socket));
   })
 
   if (post_data) {

--- a/test/socket_pool_spec.js
+++ b/test/socket_pool_spec.js
@@ -1,0 +1,57 @@
+var needle  = require('../'),
+    //sinon   = require('sinon'),
+    should  = require('should'),
+    http    = require('http'),
+    //helpers = require('./helpers');
+    server,
+    port=11112;
+
+describe('socket pool usage', function () {
+
+  describe('socket end callbacks', function () {
+
+    var httpAgent = new http.Agent({
+        keepAlive: true,
+        maxSockets: 1
+    });
+
+    before(function(){
+      server = http.createServer(function(req, res) {
+        res.setHeader('Content-Type', 'application/json')
+        res.end('{"foo":"bar"}')
+      }).listen(port);
+    });
+
+    after(function(){
+      server.close();
+    });
+
+    it('should not increase even if sockets are reused', function (done) {
+
+      var testReqCount = 10;
+      var completed = 0;
+
+      for (var i = 0; i < testReqCount; i++) {
+        needle.get('localhost:' + port, {agent: httpAgent}, function (err, resp) {
+          if (err) {
+            throw new Error("Unexpected error: " + err);
+          } else {
+            completed++;
+            // lets go through all sockets and inspect all socket objects
+            for(hostTarget in httpAgent.sockets) {
+              httpAgent.sockets[hostTarget].forEach(function (socket) {
+                // normally, there are 2 internal listeners and 1 needle sets up,
+                // but to be sure the test does not fail even if newer node versions
+                // introduce additional listeners, we use a higher limit.
+                socket.listeners('end').length.should.be.below(5, "too many listeners on the socket object's end event");
+              });
+            }
+            if (testReqCount == completed) {
+              done();
+            }
+          }
+        });
+      }
+    })
+  });
+});

--- a/test/socket_pool_spec.js
+++ b/test/socket_pool_spec.js
@@ -17,8 +17,10 @@ describe('socket pool usage', function () {
 
     before(function(){
       server = http.createServer(function(req, res) {
-        res.setHeader('Content-Type', 'application/json')
-        res.end('{"foo":"bar"}')
+        res.setHeader('Content-Type', 'application/json');
+        setTimeout(function () {
+          res.end('{"foo":"bar"}');
+        }, 50);
       }).listen(port);
     });
 

--- a/test/socket_pool_spec.js
+++ b/test/socket_pool_spec.js
@@ -31,6 +31,7 @@ describe('socket pool usage', function () {
       var testReqCount = 10;
       var completed = 0;
 
+      var lastAssertError;
       for (var i = 0; i < testReqCount; i++) {
         needle.get('localhost:' + port, {agent: httpAgent}, function (err, resp) {
           if (err) {
@@ -43,15 +44,46 @@ describe('socket pool usage', function () {
                 // normally, there are 2 internal listeners and 1 needle sets up,
                 // but to be sure the test does not fail even if newer node versions
                 // introduce additional listeners, we use a higher limit.
-                socket.listeners('end').length.should.be.below(5, "too many listeners on the socket object's end event");
+                try {
+                  socket.listeners('end').length.should.be.below(5, "too many listeners on the socket object's end event");
+                } catch (e) {
+                  lastAssertError = e;
+                }
               });
             }
             if (testReqCount == completed) {
-              done();
+              done(lastAssertError);
             }
           }
         });
       }
-    })
+    });
+
+    it('should be called when a socket is closed down', function (done) {
+
+      // This test case uses its own httpAgent to make sure we do not mess up any other
+      // socket objects kept in keep-alive state by other tests.
+      var httpAgent = new http.Agent({
+          keepAlive: true,
+          maxSockets: 1
+      });
+
+      needle.get('localhost:' + port, {agent: httpAgent}, function (err, resp) {
+        if (err) {
+          // we expect error as we just closed down the underlying socket.
+          done();
+        } else {
+          done(new Error("Request was expected to fail since the socket was closed"));
+        }
+      });
+
+      setTimeout(function () {
+        for(hostTarget in httpAgent.sockets) {
+          httpAgent.sockets[hostTarget].forEach(function (socket) {
+            socket.emit('end');
+          });
+        }
+      }, 0);
+    });
   });
 });


### PR DESCRIPTION
I tested this fix and apparently it works fine where the original version of needle did not. I am adding some more technical description to the ticket #161 on what this fix does and why.