### PR TITLE
Listen for decompressor error events

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -464,7 +464,11 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
     // To start, if our body is compressed and we're able to inflate it, do it.
     if (headers['content-encoding'] && decompressors[headers['content-encoding']]) {
-      pipeline.push(decompressors[headers['content-encoding']]());
+      var decompressor = decompressors[headers['content-encoding']]();
+      // Listen for error events
+      decompressor.on("error", had_error);
+
+      pipeline.push(decompressor);
     }
 
     // If parse is enabled and we have a parser for it, then go for it.

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -466,7 +466,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     if (headers['content-encoding'] && decompressors[headers['content-encoding']]) {
       var decompressor = decompressors[headers['content-encoding']]();
       // Listen for error events
-      decompressor.on("error", had_error);
+      decompressor.on('error', had_error);
 
       pipeline.push(decompressor);
     }

--- a/test/compression_spec.js
+++ b/test/compression_spec.js
@@ -82,6 +82,8 @@ describe('compression', function(){
       it('should rethrow errors from decompressors', function(done){
         needle.get('localhost:' + port, {headers: {'Accept-Encoding': 'deflate', 'With-Bad': 'true'}}, function(err, response, body){
           should.exist(err);
+          err.message.should.equal("unexpected end of file");
+          err.code.should.equal("Z_BUF_ERROR")
           done();
         })
       })

--- a/test/compression_spec.js
+++ b/test/compression_spec.js
@@ -34,7 +34,12 @@ describe('compression', function(){
         }
 
         res.setHeader('Content-Type', 'application/json')
-        raw.end(jsonData)
+        if(req.headers['with-bad']) {
+          res.end(null);
+        } else {
+          raw.end(jsonData)
+        }
+
       }).listen(port);
     });
 
@@ -70,6 +75,13 @@ describe('compression', function(){
           should.ifError(err);
           body.should.have.property('foo', 'bar');
           response.bytes.should.not.equal(jsonData.length);
+          done();
+        })
+      })
+
+      it('should rethrow errors from decompressors', function(done){
+        needle.get('localhost:' + port, {headers: {'Accept-Encoding': 'deflate', 'With-Bad': 'true'}}, function(err, response, body){
+          should.exist(err);
           done();
         })
       })


### PR DESCRIPTION
Noticed a malformed server response was causing uncaught errors in the client response pipeline. Small fix to register `error` handler on the decompressor stream and accompanying test.
 