### PR TITLE
Don't Decompress When Checking Header

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -463,7 +463,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
         text_response = mime.type && mime.type.indexOf('text/') != -1;
 
     // To start, if our body is compressed and we're able to inflate it, do it.
-    if (headers['content-encoding'] && decompressors[headers['content-encoding']]) {
+    if (headers['content-encoding'] && decompressors[headers['content-encoding']] && method != 'head') {
       pipeline.push(decompressors[headers['content-encoding']]());
     }
 


### PR DESCRIPTION
I ran into this strange issue when I was using `needle.head()` and `zlib` was erroring out with `unexpected end of file`.

I checked the header of the page I was accessing, it was a 404 page with `content-encoding: gzip`. This lead me to the question: Do we even need to decompress when we're only checking the header?

If your a person that believes we shouldn't, then this PR removes decompression on `.head()` calls. :))