### PR TITLE
Add encoding uri option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 temp
 sandbox
+test/keys

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ For information about options that've changed, there's always [the changelog](ht
  - `headers`     : Object containing custom HTTP headers for request. Overrides defaults described below.
  - `auth`        : Determines what to do with provided username/password. Options are `auto`, `digest` or `basic` (default). `auto` will detect the type of authentication depending on the response headers.
  - `json`        : When `true`, sets content type to `application/json` and sends request body as JSON string, instead of a query string.
+ - `encode_uri`  : When `true`, will encode the uri using `encodeURI`. Defaults to `false`.
 
 Response options
 ----------------
@@ -273,7 +274,7 @@ needle.defaults({
 
 This will override Needle's default user agent and 10-second timeout, and disable response parsing, so you don't need to pass those options in every other request.
 
-Regarding the 'Connection' header 
+Regarding the 'Connection' header
 ---------------------------------
 
 Unless you're running an old version of Node (< 0.11.4), by default Needle won't set the Connection header on requests, yielding Node's default behaviour of keeping the connection alive with the target server. This speeds up inmensely the process of sending several requests to the same host.

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -74,7 +74,8 @@ var defaults = {
   follow_set_referer      : false,
   follow_keep_method      : false,
   follow_if_same_host     : false,
-  follow_if_same_protocol : false
+  follow_if_same_protocol : false,
+  encode_uri              : false
 }
 
 var aliased = {
@@ -164,7 +165,8 @@ Needle.prototype.setup = function(uri, options) {
     proxy     : options.proxy,
     output    : options.output,
     parser    : get_option('parse_response', defaults.parse_response),
-    encoding  : options.encoding || (options.multipart ? 'binary' : defaults.encoding)
+    encoding  : options.encoding || (options.multipart ? 'binary' : defaults.encoding),
+    encode_uri: get_option('encode_uri', defaults.encode_uri)
   }
 
   keys_by_type(Boolean).forEach(function(key) {
@@ -244,7 +246,7 @@ Needle.prototype.setup = function(uri, options) {
 Needle.prototype.start = function() {
 
   var out      = new stream.PassThrough({ objectMode: false }),
-      uri      = encodeURI(this.uri),
+      uri      = this.uri,
       data     = this.data,
       method   = this.method,
       callback = (typeof this.options == 'function') ? this.options : this.callback,
@@ -255,6 +257,10 @@ Needle.prototype.start = function() {
     uri = uri.replace(/^(\/\/)?/, 'http://');
 
   var body, config = this.setup(uri, options);
+
+  if (config.encode_uri) {
+    uri = encodeURI(uri);
+  }
 
   if (data) {
 

--- a/test/encoding_uri.spec.js
+++ b/test/encoding_uri.spec.js
@@ -1,0 +1,42 @@
+var helpers = require('./helpers'),
+    should  = require('should'),
+    needle  = require('./../'),
+    server;
+
+var port = 7707;
+var sent_uri;
+var path = '/>=6.9.0%20<7.0.0';
+var uri = 'localhost:' + port + path;
+
+describe.only('URI', function() {
+
+  before(function(done) {
+    server = helpers.server({ port: port }, done);
+
+    server.on('request', function (req, res) {
+      sent_uri = req.url;
+    });
+  })
+
+  after(function(done) {
+    server.close(done);
+  })
+
+  describe('when no encode_uri option passed', function() {
+
+    it('should not encode URI', function(done) {
+      needle.get(uri, function(err, resp) {
+        sent_uri.should.eql('/%3E=6.9.0%20%3C7.0.0');
+        done();
+      })
+    })
+
+    it('should not encode URI', function(done) {
+      needle.get(uri, { encode_uri: true }, function(err, resp) {
+        sent_uri.should.eql('/%3E=6.9.0%2520%3C7.0.0');
+        done();
+      })
+    })
+
+  })
+})


### PR DESCRIPTION
This add the URI encoding as an opt-in by default to`false`.

What changes:
 - update needle to support `encode_uri` option
 - added two tests to confirm that it works
 - updated README.


This shoud fixed #183 and I confirm that it fixes https://github.com/alexanderGugel/ied/issues/164
