### PR TITLE
Fixed erroneous double encoding in URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 temp
 sandbox
+.idea

--- a/README.md
+++ b/README.md
@@ -462,6 +462,10 @@ To run tests, you need to generate a self-signed SSL certificate in the `test` d
 
 Then you should be able to run `npm test` once you have the dependencies in place.
 
+> Note: Tests currently only work on linux-based environments that have `/proc/self/fd`. They *do not* work on MacOS environments.
+> You can use Docker to run tests by creating a container and mounting the needle project directory on `/app`
+> `docker create --name Needle -v /app -w /app -v /app/node_modules -i node:argon`
+
 Credits
 -------
 

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -244,7 +244,7 @@ Needle.prototype.setup = function(uri, options) {
 Needle.prototype.start = function() {
 
   var out      = new stream.PassThrough({ objectMode: false }),
-      uri      = encodeURI(this.uri),
+      uri      = this.uri,
       data     = this.data,
       method   = this.method,
       callback = (typeof this.options == 'function') ? this.options : this.callback,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -58,6 +58,7 @@ helpers.server = function(opts, cb) {
   };
 
   var protocol = opts.protocol || 'http';
+  var server;
 
   if (protocol == 'https')
     server = protocols[protocol].createServer(keys, handler);

--- a/test/url_spec.js
+++ b/test/url_spec.js
@@ -12,12 +12,12 @@ describe('urls', function() {
     return needle.get(url, cb);
   }
 
-  before(function(){
-    server = helpers.server({ port: 3333 });
+  before(function(done){
+    server = helpers.server({ port: 3333 }, done);
   })
 
-  after(function(){
-    server.close();
+  after(function(done) {
+    server.close(done);
   })
 
   describe('null URL', function(){
@@ -122,6 +122,25 @@ describe('urls', function() {
         done();
       })
     })
+
+  })
+
+  describe('double encoding', function() {
+
+    var path = '/foo?email=' + encodeURIComponent('what-ever@Example.Com');
+
+    before(function() {
+      url = 'localhost:3333' + path
+    });
+
+    it('should not occur', function(done) {
+      send_request(function(err, res) {
+        should.not.exist(err);
+        should(res.req.path).be.exactly(path);
+        done();
+      });
+
+    });
 
   })
 


### PR DESCRIPTION
Effectively rolls back #171.

URL encoding is the responsibility of the developer / application, not needle. 

Consider this example:

```js
needle.get('foo.app/accounts?email=' + encodeURIComponent('foo@example.com'), (err, res) => ... );
```

You'd actually end up sending a doubly-encoded URL.

Also included in this PR:
 * URL encoding should be handled by the application.
 * Added supporting unit test
 * Fixed missing var declaration in test/helpers.js
 * Added callbacks to before/after in test/url_spec.js
 * Added note about running unit test environments