### PR TITLE
Adding 307 as a valid redirection code

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -420,7 +420,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     }
 
     // if redirect code is found, send a GET request to that location if enabled via 'follow' option
-    if ([301, 302, 303].indexOf(resp.statusCode) !== -1 && self.should_follow(headers.location, config, uri)) {
+    if ([301, 302, 303, 307].indexOf(resp.statusCode) !== -1 && self.should_follow(headers.location, config, uri)) {
 
       if (count <= config.follow_max) {
         out.emit('redirect', headers.location);


### PR DESCRIPTION
307 code is a valid redirection and is not accepted by Needle so far. 

As explained by the [w3.org](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) website: 

> 10.3.8 307 Temporary Redirect
> 
> The requested resource resides temporarily under a different URI. Since the redirection MAY be altered on occasion, the client SHOULD continue to use the Request-URI for future requests. This response is only cacheable if indicated by a Cache-Control or Expires header field.
> 
> The temporary URI SHOULD be given by the Location field in the response. Unless the request method was HEAD, the entity of the response SHOULD contain a short hypertext note with a hyperlink to the new URI(s) , since many pre-HTTP/1.1 user agents do not understand the 307 status. Therefore, the note SHOULD contain the information necessary for a user to repeat the original request on the new URI.
> 
> If the 307 status code is received in response to a request other than GET or HEAD, the user agent MUST NOT automatically redirect the request unless it can be confirmed by the user, since this might change the conditions under which the request was issued.