### PR TITLE
Persist cookies across redirects when follow_set_cookies is true

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -48,6 +48,7 @@ function parseSetCookieString(str) {
 // Parses a set-cookie-header and returns a key/value object.
 // Each key represents the name of a cookie.
 function parseSetCookieHeader(header) {
+  if (!header) return {};
   header = (header instanceof Array) ? header : [header];
 
   return header.reduce(function(res, str) {

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -33,6 +33,9 @@ var tls_options = 'agent pfx key passphrase cert ca ciphers rejectUnauthorized s
 // we'll default new requests to set a Connection: close header.
 var close_by_default = !http.Agent || http.Agent.defaultMaxSockets != Infinity;
 
+// see if we have Object.assign. otherwise fall back to util._extend
+var extend = Object.assign ? Object.assign : require('util')._extend;
+
 //////////////////////////////////////////
 // decompressors for gzip/deflate bodies
 
@@ -414,8 +417,10 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     if (timer) clearTimeout(timer);
     set_timeout(config.read_timeout);
 
-    if (headers['set-cookie'] && config.parse_cookies) {
-      resp.cookies = cookies.read(headers['set-cookie']);
+    // if we got cookies, parse them unless we were instructed not to. make sure to include any
+    // cookies that might have been set on previous redirects.
+    if (config.parse_cookies && (headers['set-cookie'] || config.stored_cookies)) {
+      resp.cookies = extend(config.stored_cookies || {}, cookies.read(headers['set-cookie']));
       debug('Got cookies', resp.cookies);
     }
 
@@ -432,13 +437,15 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
           delete config.headers['content-length']; // in case the original was a multipart POST request.
         }
 
-        if (config.follow_set_cookies && resp.cookies)
+        // if follow_set_cookies is true, make sure to put any cookies in the next request's headers.
+        if (config.follow_set_cookies && resp.cookies) {
+          config.stored_cookies    = resp.cookies;
           config.headers['cookie'] = cookies.write(resp.cookies);
+        }
 
         if (config.follow_set_referer)
           config.headers['referer'] = uri; // the original, not the destination URL.
 
-        config.headers['host'] = null; // clear previous Host header to avoid conflicts.
 
         debug('Redirecting to ' + url.resolve(uri, headers.location));
         return self.send_request(++count, method, url.resolve(uri, headers.location), config, post_data, out, callback);

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -446,6 +446,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
         if (config.follow_set_referer)
           config.headers['referer'] = uri; // the original, not the destination URL.
 
+        config.headers['host'] = null; // clear previous Host header to avoid conflicts.
 
         debug('Redirecting to ' + url.resolve(uri, headers.location));
         return self.send_request(++count, method, url.resolve(uri, headers.location), config, post_data, out, callback);


### PR DESCRIPTION
Refactored version of #129. Also handles the scenario when redirect cookies are persisted but last response doesn't include any (resp.cookies should return the previous cookies anyway).