### PR TITLE
Skip malformed cookies

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -38,11 +38,15 @@ function parseSetCookieString(str) {
 
   var res = COOKIE_PAIR.exec(str);
   if (!res || !res[VALUE_INDEX]) return null;
-
-  return {
-    name  : decodeURIComponent(res[KEY_INDEX]),
-    value : decodeURIComponent(res[VALUE_INDEX])
-  };
+  try{
+    return {
+      name  : decodeURIComponent(res[KEY_INDEX]),
+      value : decodeURIComponent(res[VALUE_INDEX])
+    };
+  }catch(err){
+  // Skip malformed cookies
+    return null;
+  }
 }
 
 // Parses a set-cookie-header and returns a key/value object.


### PR DESCRIPTION
Some artisan russian programmers still use windows-1251 cookie values, which gives URIError: URI malformed
. I added try/catch to skip malformed cookies, since their recovery seems to be too much of a trouble. Url to reproduce: http://www.raskraski.ru/cat_raskraski_po_nomeram.html, malformed cookie was geo_city=%D1%E0%ED%EA%F2-%CF%E5%F2%E5%F0%E1%F3%F0%E3