### PR TITLE
Fix timeout issue when following redirects

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -453,6 +453,8 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     timer = setTimeout(function() {
       out.emit('timeout', type);
       request.abort();
+      // also invoke done() to terminate job on read_timeout
+      if (type == 'read') done(new Error(type + ' timeout'));
     }, milisecs);
   }
 
@@ -486,7 +488,9 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
     // if redirect code is found, determine if we should follow it according to the given options.
     if (redirect_codes.indexOf(resp.statusCode) !== -1 && self.should_follow(headers.location, config, uri)) {
-
+      // clear timer before following redirects to prevent unexpected setTimeout consequence
+      clearTimeout(timer);
+      
       if (count <= config.follow_max) {
         out.emit('redirect', headers.location);
 

--- a/test/redirect_with_timeout.js
+++ b/test/redirect_with_timeout.js
@@ -1,0 +1,45 @@
+var should  = require('should')
+var needle  = require('./../')
+
+describe('follow redirects when read_timeout is set', function () {
+
+    it('clear timeout before following redirect', function (done) {
+        var opts = {
+            open_timeout: 1000,
+            read_timeout: 3000,
+            follow: 5,
+            user_agent: 'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36'
+        }
+
+        var timedOut = 0
+        var redirects = 0
+
+        var timer = setTimeout(function () {
+            var hasRedirects = redirects > 0
+            hasRedirects.should.equal(true)
+            done()
+        }, opts.read_timeout || 3000)
+
+        var resp = needle.get('http://google.com/', opts, function (err, resp, body) {
+            var noErr = err === null
+            var hasBody = body.length > 0
+            noErr.should.equal(true);
+            hasBody.should.equal(true);
+        });
+
+        resp.on('redirect', function (location) {
+            redirects++
+            // console.info('    Redirected to ', location)
+        })
+
+        resp.on('timeout', function (type) {
+            timedOut++
+            timedOut.should.equal(0)
+            // console.error('   ', type, 'timeout')
+            clearTimeout(timer)
+            done()
+        })
+
+    }).timeout(30000)
+
+})


### PR DESCRIPTION
When following redirects the timer variable will be created multiple times if open_timeout and/or read_timeout is set (>0).

This makes the script always wait until setTimeout is invoked, thus always emit the timeout event.

Quick fix:
- clearTimeout before following redirects
- also invoke done() inside setTimeout() function on read_timeout to terminate the job correctly