### PR TITLE
catch sync errors from http/s protocols and add abort option on the output

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -441,6 +441,15 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     out.emit('done', err);
   }
 
+  out.abort = function abort() {
+    request.abort();
+
+    if (timer) clearTimeout(timer);
+    request.removeListener('error', had_error);
+
+    out.emit('abort')
+  }
+
   function had_error(err) {
     debug('Request error', err);
     out.emit('err', err);

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -431,7 +431,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
       return debug('Already finished, stopping here.');
 
     if (timer) clearTimeout(timer);
-    request.removeListener('error', had_error);
+    request && request.removeListener('error', had_error);
 
     if (callback)
       return callback(err, resp, resp ? resp.body : undefined);
@@ -468,8 +468,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     }
   }
 
-  debug('Making request #' + count, request_opts);
-  var request = protocol.request(request_opts, function(resp) {
+  function request_callback(resp) {
 
     var headers = resp.headers;
     debug('Got response', resp.statusCode, headers);
@@ -686,7 +685,16 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
     });
 
-  }); // end request call
+  }
+
+  debug('Making request #' + count, request_opts);
+  try {
+    var request = protocol.request(request_opts, request_callback); // end request call
+  } catch (e) {
+    had_error(e)
+    return
+  }
+
 
   // unless open_timeout was disabled, set a timeout to abort the request.
   set_timeout('open', config.open_timeout);


### PR DESCRIPTION
http/s protocol when requesting make a first parse and other actions that are sync, and we need to catch those errors.

Once we make a request and we get the output stream we require a way to abort the request,
even if we destroy the stream the request connections is open and then this can cause some weird
errors like `connect ENOBUFS` or some failing timeouts.