### PR TITLE
Use Array.isArray to check for array

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -51,7 +51,7 @@ function parseSetCookieString(str) {
 // Each key represents the name of a cookie.
 function parseSetCookieHeader(header) {
   if (!header) return {};
-  header = (header instanceof Array) ? header : [header];
+  header = Array.isArray(header) ? header : [header];
 
   return header.reduce(function(res, str) {
     var cookie = parseSetCookieString(str);


### PR DESCRIPTION
Jest has issues with native prototype identity, so it fails the `instanceof` check. Using `Array.isArray` fixes the issue.

Merging will fix https://github.com/facebook/jest/issues/4996