### PR TITLE
Use an if statement to handle absence of charset in Content-Type header

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -121,8 +121,12 @@ function keys_by_type(type) {
 function parse_content_type(header) {
   if (!header || header === '') return {};
 
-  var charset = 'iso-8859-1', arr = header.split(';');
-  try { charset = arr[1].match(/charset=(.+)/)[1] } catch (e) { /* not found */ }
+  var charset = "iso-8859-1",
+    arr = header.split(";"),
+    sent_charset = null;
+  if (arr.length > 1 && (sent_charset = arr[1].match(/charset=(.+)/)) && sent_charset.length > 1) {
+    charset = sent_charset[1]; /* found */
+  }
 
   return { type: arr[0], charset: charset };
 }


### PR DESCRIPTION
## Motivation

I use vscode when debugging my code, and have pause on exceptions enabled.
This means every time I receive from the remote API I'm testing (which does not set a charset in the content type), Execution gets paused.

## Expected gains from this change

Using an if statement as done in this PR will ensure we only set the charset when one is present. It also ensure we don't lose performance when the APIs called will never set a charset.