### PR TITLE
Include sax parser as a dependency and use our own simple parser instead of xml2js

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ When no callback is passed, however, the buffering logic will be skipped but the
 Response pipeline
 -----------------
 
-Depending on the response's Content-Type, Needle will either attempt to parse JSON or XML streams, or, if a text response was received, will ensure that the final encoding you get is UTF-8. For XML decoding to work, though, you'll need to install the `xml2js` package as we don't enforce unneeded dependencies unless strictly needed.
+Depending on the response's Content-Type, Needle will either attempt to parse JSON or XML streams, or, if a text response was received, will ensure that the final encoding you get is UTF-8.
 
 You can also request a gzip/deflated response, which, if sent by the server, will be processed before parsing or decoding is performed.
 
@@ -322,8 +322,6 @@ Response options
  - `output`          : Dump response output to file. This occurs after parsing and charset decoding is done.
  - `parse_cookies`   : Whether to parse response’s `Set-Cookie` header. Defaults to `true`. If parsed, response cookies will be available at `resp.cookies`.
 
-Note: To stay light on dependencies, Needle doesn't include the `xml2js` module used for XML parsing. To enable it, simply do `npm install xml2js`.
-
 HTTP Header options
 -------------------
 
@@ -448,7 +446,7 @@ needle.get('api.github.com/users/tomas', options, function(err, resp, body) {
 
 ```js
 needle.get('https://news.ycombinator.com/rss', function(err, resp, body) {
-  // if xml2js is installed, you'll get a nice object containing the nodes in the RSS
+  // you'll get a nice object containing the nodes in the RSS
 });
 ```
 

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -47,7 +47,6 @@ var decompressors = {};
 try {
 
   var zlib = require('zlib');
-
   decompressors['x-deflate'] = zlib.Inflate;
   decompressors['deflate']   = zlib.Inflate;
   decompressors['x-gzip']    = zlib.Gunzip;
@@ -149,7 +148,6 @@ function get_stream_length(stream, given_length, cb) {
 // the main act
 
 function Needle(method, uri, data, options, callback) {
-
   // if (!(this instanceof Needle)) {
   //   return new Needle(method, uri, data, options, callback);
   // }
@@ -172,6 +170,7 @@ function Needle(method, uri, data, options, callback) {
 }
 
 Needle.prototype.setup = function(uri, options) {
+
   function get_option(key, fallback) {
     // if original is in options, return that value
     if (typeof options[key] != 'undefined') return options[key];
@@ -651,7 +650,6 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
     // And set the .body property once all data is in.
     out.on('end', function() {
-
       if (resp.body) { // callback mode
 
         // we want to be able to access to the raw data later, so keep a reference.

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -10,30 +10,22 @@ function parseXML(str, cb) {
   var obj, current, parser = sax.parser(true, { trim: true, lowercase: true })
   parser.onerror = parser.onend = done;
 
-  function start() {
-    try {
-      parser.write(str).close()
-    } catch(e) {
-      done(e)
-    }
-  }
-
   function done(err) {
+    parser.onerror = parser.onend = function() { }
     cb(err, obj)
-    done = function() { };
   }
 
   function newElement(name, attributes) {
     return {
       name: name || '',
-      text: '',
+      value: '',
       attributes: attributes || {},
       children: []
     }
   }
 
   parser.ontext = function(t) {
-    if (current) current.text += t
+    if (current) current.value += t
   }
 
   parser.onopentag = function(node) {
@@ -56,7 +48,7 @@ function parseXML(str, cb) {
     }
   }
 
-  start()
+  parser.write(str).close()
 }
 
 function parserFactory(name, fn) {
@@ -94,23 +86,35 @@ function parserFactory(name, fn) {
   return { fn: parser, name: name };
 }
 
-var json = parserFactory('json', function(buffer, cb) {
+var parsers = {}
+
+function buildParser(name, types, fn) {
+  var parser = parserFactory(name, fn);
+  types.forEach(function(type) {
+    parsers[type] = parser;
+  })
+}
+
+buildParser('json', [
+  'application/json',
+  'text/javascript'
+], function(buffer, cb) {
   var err, data;
   try { data = JSON.parse(buffer); } catch (e) { err = e; }
   cb(err, data);
 });
 
-module.exports['application/json'] = json;
-module.exports['text/javascript']  = json;
-
-var xml = parserFactory('xml', function(buffer, cb) {
+buildParser('xml', [
+  'text/xml',
+  'application/xml',
+  'application/rdf+xml',
+  'application/rss+xml',
+  'application/atom+xml'
+], function(buffer, cb) {
   parseXML(buffer.toString(), function(err, obj) {
     cb(err, obj)
   })
 });
 
-module.exports['text/xml']             = xml;
-module.exports['application/xml']      = xml;
-module.exports['application/rdf+xml']  = xml;
-module.exports['application/rss+xml']  = xml;
-module.exports['application/atom+xml'] = xml;
+module.exports = parsers;
+module.exports.use = buildParser;

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -4,6 +4,71 @@
 //////////////////////////////////////////
 
 var Transform = require('stream').Transform;
+var sax = require('sax');
+
+function parseXML(str, cb) {
+  var obj, current, parser = sax.parser(true, { trim: true, lowercase: true })
+  parser.onerror = parser.onend = done;
+
+  function start() {
+    try {
+      parser.write(str).close()
+    } catch(e) {
+      done(e)
+    }
+  }
+
+  function done(err) {
+    cb(err, obj)
+    done = function() { };
+  }
+
+  function newElement(name, attributes) {
+    return {
+      name: name || '',
+      text: '',
+      attributes: attributes || {},
+      children: []
+    }
+  }
+
+  function toAttribute(parent, element) {
+    if (typeof parent[element.name] === 'undefined')
+      return parent[element.name] = element
+
+    if (parent[element.name].constructor == Object)
+      parent[element.name] = [parent[element.name]]
+
+    parent[element.name].push(element)
+  }
+
+  parser.ontext = function(t) {
+    if (current) current.text += t
+  }
+
+  parser.onopentag = function(node) {
+    var element = newElement(node.name, node.attributes)
+    if (current) {
+      element.parent = current
+      current.children.push(element)
+      toAttribute(current, element)
+    } else {
+      obj = element
+    }
+
+    current = element
+  };
+
+  parser.onclosetag = function() {
+    if (typeof current.parent !== 'undefined') {
+      var just_closed = current
+      current = current.parent
+      delete just_closed.parent
+    }
+  }
+
+  start()
+}
 
 function parserFactory(name, fn) {
 
@@ -49,21 +114,14 @@ var json = parserFactory('json', function(buffer, cb) {
 module.exports['application/json'] = json;
 module.exports['text/javascript']  = json;
 
-try {
+var xml = parserFactory('xml', function(buffer, cb) {
+  parseXML(buffer.toString(), function(err, obj) {
+    cb(err, data)
+  })
+});
 
-  var xml2js = require('xml2js');
-
-  // xml2js.Parser.parseString() has the exact same function signature
-  // as our ParseStream expects, so we can reuse this.
-  var xml = parserFactory('xml', new xml2js.Parser({
-    explicitRoot : true,
-    explicitArray: false
-  }).parseString, true);
-
-  module.exports['text/xml']             = xml;
-  module.exports['application/xml']      = xml;
-  module.exports['application/rdf+xml']  = xml;
-  module.exports['application/rss+xml']  = xml;
-  module.exports['application/atom+xml'] = xml;
-
-} catch(e) { /* xml2js not found */ }
+module.exports['text/xml']             = xml;
+module.exports['application/xml']      = xml;
+module.exports['application/rdf+xml']  = xml;
+module.exports['application/rss+xml']  = xml;
+module.exports['application/atom+xml'] = xml;

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -32,16 +32,6 @@ function parseXML(str, cb) {
     }
   }
 
-  function toAttribute(parent, element) {
-    if (typeof parent[element.name] === 'undefined')
-      return parent[element.name] = element
-
-    if (parent[element.name].constructor == Object)
-      parent[element.name] = [parent[element.name]]
-
-    parent[element.name].push(element)
-  }
-
   parser.ontext = function(t) {
     if (current) current.text += t
   }
@@ -51,7 +41,6 @@ function parseXML(str, cb) {
     if (current) {
       element.parent = current
       current.children.push(element)
-      toAttribute(current, element)
     } else {
       obj = element
     }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -105,7 +105,7 @@ module.exports['text/javascript']  = json;
 
 var xml = parserFactory('xml', function(buffer, cb) {
   parseXML(buffer.toString(), function(err, obj) {
-    cb(err, data)
+    cb(err, obj)
   })
 });
 

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -41,7 +41,7 @@ function parseXML(str, cb) {
     if (current) {
       element.parent = current
       current.children.push(element)
-    } else {
+    } else { // root object
       obj = element
     }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   },
   "dependencies": {
     "debug": "^2.1.2",
-    "iconv-lite": "^0.4.4"
+    "iconv-lite": "^0.4.4",
+    "sax": "^1.2.4"
   },
   "devDependencies": {
     "mocha": "",

--- a/test/parsing_spec.js
+++ b/test/parsing_spec.js
@@ -318,48 +318,47 @@ describe('parsing', function(){
       server.close(done);
     })
 
-    describe('and xml2js library is present', function(){
+    describe('and parse_response is true', function(){
 
-      require.bind(null, 'xml2js').should.not.throw();
-
-      describe('and parse_response is true', function(){
-
-        it('should return valid object', function(done){
-          needle.get('localhost:' + port, function(err, response, body){
-            should.not.exist(err);
-            body.post.should.have.property('body', 'hello there');
-            done();
-          })
+      it('should return valid object', function(done) {
+        needle.get('localhost:' + port, { parse_response: true }, function(err, response, body) {
+          should.not.exist(err);
+          body.name.should.eql('post')
+          body.children[0].name.should.eql('body')
+          body.children[0].text.should.eql('hello there')
+          done();
         })
-
-        it('should have a .parser = json property', function(done) {
-          needle.get('localhost:' + port, function(err, resp) {
-            should.not.exist(err);
-            resp.parser.should.eql('xml');
-            done();
-          })
-        })
-
       })
 
-      describe('and parse response is not true', function(){
-
-        it('should return xml string', function(){
-
+      it('should have a .parser = json property', function(done) {
+        needle.get('localhost:' + port, { parse_response: true }, function(err, resp) {
+          should.not.exist(err);
+          resp.parser.should.eql('xml');
+          done();
         })
-
       })
 
     })
 
-    describe('and xml2js is not found', function(){
+    describe('and parse response is false', function(){
 
-      it('should return xml string', function(){
+      it('should return valid object', function(done) {
+        needle.get('localhost:' + port, { parse_response: false }, function(err, response, body){
+          should.not.exist(err);
+          body.toString().should.eql('<post><body>hello there</body></post>')
+          done();
+        })
+      })
 
+      it('should not have a .parser = json property', function(done) {
+        needle.get('localhost:' + port, { parse_response: false }, function(err, resp) {
+          should.not.exist(err);
+          should.not.exist(resp.parser)
+          done();
+        })
       })
 
     })
-
 
   })
 


### PR DESCRIPTION
This way we don't rely on optional dependencies, which can get in the way when trying to bundle needle via rollup, webpack or browserify.