### PR TITLE
Flag Node 4 as minium supported Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 0.10.x"
+    "node": ">= 4"
   }
 }


### PR DESCRIPTION
https://github.com/tomas/needle/commit/137ee14f4c7f1047185a9e6e8fd5d0a3b2e8ae7d swapped `var` for `const`, so it won't running on Node < 4