### PR TITLE
Improve sample to clarify how to send JSON data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ needle
 From version 2.0.x up, Promises are also supported. Just call `needle()` directly and you'll get a native Promise object.
 
 ```js
-needle('put', 'https://hacking.the.gibson/login', { password: 'god' })
+needle('put', 'https://hacking.the.gibson/login', { password: 'god' }, { json: true })
   .then(function(response) {
     return doSomethingWith(response)
   })


### PR DESCRIPTION
Hi everyone 😊 

One of the first examples in the `README.md` shows how to send JSON data, but it is missing the appropriate setting so that the `content-type` header is set in a correct way. This is misleading, hence I have added the missing option.

Hope this helps 😊 