### PR TITLE
Add permanent redirect status code

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -37,7 +37,7 @@ var close_by_default = !http.Agent || http.Agent.defaultMaxSockets != Infinity;
 var extend = Object.assign ? Object.assign : require('util')._extend;
 
 // these are the status codes that Needle interprets as redirects.
-var redirect_codes = [301, 302, 303, 307];
+var redirect_codes = [301, 302, 303, 307, 308];
 
 //////////////////////////////////////////
 // decompressors for gzip/deflate/br bodies


### PR DESCRIPTION
Add permanent redirect status code to allowed redirect status codes

308 Permanent redirect is also a valid redirect status code
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308