### PR TITLE
test: change octal escape to Unicode escape

### DIFF
--- a/test/url_spec.js
+++ b/test/url_spec.js
@@ -59,7 +59,7 @@ describe('urls', function() {
   describe('invalid host', function(){
 
     before(function() {
-      url = 'http://s1\\\2.com/'
+      url = 'http://s1\\\u0002.com/'
     })
 
     it('fails', function(done) {


### PR DESCRIPTION
When performing an eslint-driven security audit (using `babel-eslint` and looking for things like `eval`), I got this parsing error in your test file, preventing me from auditing here.

I've therefore converted this octal escape to a Unicode escape, and since it should be treated exactly the same (and would be needed if you ever went to strict mode), I figure I'd submit the fix, especially if you didn't want to just ignore the test folder in a future release.

Thanks!