### PR TITLE
Add `follow_if_different_location` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,12 +355,12 @@ Redirect options
 
 These options only apply if the `follow_max` (or `follow`) option is higher than 0.
 
- - `follow_set_cookies`           : Sends the cookies received in the `set-cookie` header as part of the following request. `false` by default.
- - `follow_set_referer`           : Sets the 'Referer' header to the requested URI when following a redirect. `false` by default.
- - `follow_keep_method`           : If enabled, resends the request using the original verb instead of being rewritten to `get` with no data. `false` by default.
- - `follow_if_same_host`          : When true, Needle will only follow redirects that point to the same host as the original request. `false` by default.
- - `follow_if_same_protocol`      : When true, Needle will only follow redirects that point to the same protocol as the original request. `false` by default.
- - `follow_if_different_location` : When true, Needle will only follow redirects that point to a different location as the original request. `true` by default.
+ - `follow_set_cookies`      : Sends the cookies received in the `set-cookie` header as part of the following request. `false` by default.
+ - `follow_set_referer`      : Sets the 'Referer' header to the requested URI when following a redirect. `false` by default.
+ - `follow_keep_method`      : If enabled, resends the request using the original verb instead of being rewritten to `get` with no data. `false` by default.
+ - `follow_if_same_host`     : When true, Needle will only follow redirects that point to the same host as the original request. `false` by default.
+ - `follow_if_same_protocol` : When true, Needle will only follow redirects that point to the same protocol as the original request. `false` by default.
+ - `follow_if_same_location` : When true, Needle will follow redirects that point to same location as the original request. `false` by default.
 
 Overriding Defaults
 -------------------

--- a/README.md
+++ b/README.md
@@ -355,11 +355,12 @@ Redirect options
 
 These options only apply if the `follow_max` (or `follow`) option is higher than 0.
 
- - `follow_set_cookies`      : Sends the cookies received in the `set-cookie` header as part of the following request. `false` by default.
- - `follow_set_referer`      : Sets the 'Referer' header to the requested URI when following a redirect. `false` by default.
- - `follow_keep_method`      : If enabled, resends the request using the original verb instead of being rewritten to `get` with no data. `false` by default.
- - `follow_if_same_host`     : When true, Needle will only follow redirects that point to the same host as the original request. `false` by default.
- - `follow_if_same_protocol` : When true, Needle will only follow redirects that point to the same protocol as the original request. `false` by default.
+ - `follow_set_cookies`           : Sends the cookies received in the `set-cookie` header as part of the following request. `false` by default.
+ - `follow_set_referer`           : Sets the 'Referer' header to the requested URI when following a redirect. `false` by default.
+ - `follow_keep_method`           : If enabled, resends the request using the original verb instead of being rewritten to `get` with no data. `false` by default.
+ - `follow_if_same_host`          : When true, Needle will only follow redirects that point to the same host as the original request. `false` by default.
+ - `follow_if_same_protocol`      : When true, Needle will only follow redirects that point to the same protocol as the original request. `false` by default.
+ - `follow_if_different_location` : When true, Needle will only follow redirects that point to a different location as the original request. `true` by default.
 
 Overriding Defaults
 -------------------

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -87,14 +87,15 @@ var defaults = {
   stream_length           : -1,
 
   // booleans
-  compressed              : false,
-  decode_response         : true,
-  parse_cookies           : true,
-  follow_set_cookies      : false,
-  follow_set_referer      : false,
-  follow_keep_method      : false,
-  follow_if_same_host     : false,
-  follow_if_same_protocol : false
+  compressed                   : false,
+  decode_response              : true,
+  parse_cookies                : true,
+  follow_set_cookies           : false,
+  follow_set_referer           : false,
+  follow_keep_method           : false,
+  follow_if_same_host          : false,
+  follow_if_same_protocol      : false,
+  follow_if_different_location : true
 }
 
 var aliased = {
@@ -417,7 +418,7 @@ Needle.prototype.should_follow = function(location, config, original) {
   }
 
   // first, check whether the requested location is actually different from the original
-  if (location === original)
+  if (config.follow_if_different_location && location === original)
     return false;
 
   if (config.follow_if_same_host && !matches('host'))

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -87,15 +87,15 @@ var defaults = {
   stream_length           : -1,
 
   // booleans
-  compressed                   : false,
-  decode_response              : true,
-  parse_cookies                : true,
-  follow_set_cookies           : false,
-  follow_set_referer           : false,
-  follow_keep_method           : false,
-  follow_if_same_host          : false,
-  follow_if_same_protocol      : false,
-  follow_if_different_location : true
+  compressed              : false,
+  decode_response         : true,
+  parse_cookies           : true,
+  follow_set_cookies      : false,
+  follow_set_referer      : false,
+  follow_keep_method      : false,
+  follow_if_same_host     : false,
+  follow_if_same_protocol : false,
+  follow_if_same_location : false
 }
 
 var aliased = {
@@ -418,7 +418,7 @@ Needle.prototype.should_follow = function(location, config, original) {
   }
 
   // first, check whether the requested location is actually different from the original
-  if (config.follow_if_different_location && location === original)
+  if (!config.follow_if_same_location && location === original)
     return false;
 
   if (config.follow_if_same_host && !matches('host'))


### PR DESCRIPTION
I added `follow_if_different_location` in order to be able to decide if we want to process redirect if location in the same.

We have example of websites redirecting with same location but with different cookies  and so not ending with a redirection loop. So in this case we do not want to stop redirections.