### PR TITLE
Fix parsing xml CDATA values

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -24,7 +24,7 @@ function parseXML(str, cb) {
     }
   }
 
-  parser.ontext = function(t) {
+  parser.oncdata = parser.ontext = function(t) {
     if (current) current.value += t
   }
 

--- a/test/parsing_spec.js
+++ b/test/parsing_spec.js
@@ -366,7 +366,7 @@ describe('parsing', function(){
     before(function(done) {
       server = http.createServer(function(req, res) {
         res.writeHeader(200, {'Content-Type': 'application/xml'})
-        res.end("<post><p>hello</p><p>world</p></post>")
+        res.end("<post><p>hello</p><p><![CDATA[world]]></p></post>")
       }).listen(port, done);
     });
 
@@ -404,7 +404,7 @@ describe('parsing', function(){
       it('should return valid object', function(done) {
         needle.get('localhost:' + port, { parse_response: false }, function(err, response, body){
           should.not.exist(err);
-          body.toString().should.eql('<post><p>hello</p><p>world</p></post>')
+          body.toString().should.eql('<post><p>hello</p><p><![CDATA[world]]></p></post>')
           done();
         })
       })


### PR DESCRIPTION
Currently xml values inside CDATA result to empty string.
 For example xml
```xml
<Tag>
  <![CDATA[live]]>
</Tag>
```
results in ```[{ name: 'Tag', value: '', attributes: [], children: [] }]```
while expected result would be ```[{ name: 'Tag', value: 'live', attributes: [], children: [] }]```