### PR TITLE
Simple request URI modification logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ For information about options that've changed, there's always [the changelog](ht
  - `auth`        : Determines what to do with provided username/password. Options are `auto`, `digest` or `basic` (default). `auto` will detect the type of authentication depending on the response headers.
  - `stream_length`: When sending streams, this lets you manually set the Content-Length header --if the stream's bytecount is known beforehand--, preventing ECONNRESET (socket hang up) errors on some servers that misbehave when receiving payloads of unknown size. Set it to `0` and Needle will get and set the stream's length for you, or leave unset for the default behaviour, which is no Content-Length header for stream payloads.
  - `localAddress`     : <string>, IP address. Passed to http/https request. Local interface from witch the request should be emitted.
+ - `uri_mod`     : A lambda function taking request (also redirect follow-up) URI as an argument and modifying it given logic. It has to return a valid URI string for successful request.
 
 Response options
 ----------------

--- a/README.md
+++ b/README.md
@@ -312,8 +312,8 @@ For information about options that've changed, there's always [the changelog](ht
  - `headers`     : Object containing custom HTTP headers for request. Overrides defaults described below.
  - `auth`        : Determines what to do with provided username/password. Options are `auto`, `digest` or `basic` (default). `auto` will detect the type of authentication depending on the response headers.
  - `stream_length`: When sending streams, this lets you manually set the Content-Length header --if the stream's bytecount is known beforehand--, preventing ECONNRESET (socket hang up) errors on some servers that misbehave when receiving payloads of unknown size. Set it to `0` and Needle will get and set the stream's length for you, or leave unset for the default behaviour, which is no Content-Length header for stream payloads.
- - `localAddress`     : <string>, IP address. Passed to http/https request. Local interface from witch the request should be emitted.
- - `uri_mod`     : A lambda function taking request (also redirect follow-up) URI as an argument and modifying it given logic. It has to return a valid URI string for successful request.
+ - `localAddress`: <string>, IP address. Passed to http/https request. Local interface from witch the request should be emitted.
+ - `uri_modifier`: Anonymous function taking request (or redirect location if following redirects) URI as an argument and modifying it given logic. It has to return a valid URI string for successful request.
 
 Response options
 ----------------

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -287,7 +287,7 @@ Needle.prototype.setup = function(uri, options) {
   for (var h in options.headers)
     config.headers[h.toLowerCase()] = options.headers[h];
 
-  config.uri_mod = get_option('uri_mod', null);
+  config.uri_modifier = get_option('uri_modifier', null);
 
   return config;
 }
@@ -437,9 +437,9 @@ Needle.prototype.should_follow = function(location, config, original) {
 
 Needle.prototype.send_request = function(count, method, uri, config, post_data, out, callback) {
 
-  if (typeof config.uri_mod === 'function') {
-    var modified_uri = config.uri_mod(uri);
-    debug('Modifying request URI', uri, modified_uri);
+  if (typeof config.uri_modifier === 'function') {
+    var modified_uri = config.uri_modifier(uri);
+    debug('Modifying request URI', uri + ' => ' + modified_uri);
     uri = modified_uri;
   }
 

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -287,6 +287,8 @@ Needle.prototype.setup = function(uri, options) {
   for (var h in options.headers)
     config.headers[h.toLowerCase()] = options.headers[h];
 
+  config.uri_mod = get_option('uri_mod', null);
+
   return config;
 }
 
@@ -435,6 +437,12 @@ Needle.prototype.should_follow = function(location, config, original) {
 
 Needle.prototype.send_request = function(count, method, uri, config, post_data, out, callback) {
 
+  if (typeof config.uri_mod === 'function') {
+    var modified_uri = config.uri_mod(uri);
+    debug('Modifying request URI', uri, modified_uri);
+    uri = modified_uri;
+  }
+
   var timer,
       returned     = 0,
       self         = this,
@@ -520,7 +528,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
         if (config.follow_set_cookies) {
           var request_cookies = cookies.read(config.headers['cookie']);
           config.previous_resp_cookies = resp.cookies;
-          if (Object.keys(request_cookies).length || Object.keys(resp.cookies).length) {
+          if (Object.keys(request_cookies).length || Object.keys(resp.cookies || {}).length) {
             config.headers['cookie'] = cookies.write(extend(request_cookies, resp.cookies));
           }
         } else if (config.headers['cookie']) {

--- a/test/uri_mod_spec.js
+++ b/test/uri_mod_spec.js
@@ -1,0 +1,46 @@
+var needle  = require('../'),
+    sinon   = require('sinon'),
+    should  = require('should'),
+    http    = require('http'),
+    helpers = require('./helpers');
+
+var port = 3456;
+
+describe('uri_mod config parameter function', function() {
+
+  var server, uri;
+
+  function send_request(mw, cb) {
+    return needle.get(uri, null, { uri_mod: mw }, cb);
+  }
+
+  before(function(done){
+    server = helpers.server({ port: port }, done);
+  })
+
+  after(function(done) {
+    server.close(done);
+  })
+
+  describe('modifies uri', function(){
+
+    var path = '/foo/replace';
+
+    before(function() {
+      uri = 'localhost:' + port + path
+    });
+
+    it('should modify path', function(done) {
+      send_request(function(uri) {
+        return uri.replace('/replace', '');
+      }, function(err, res) {
+        should.not.exist(err);
+        should(res.req.path).be.exactly('/foo');
+        done();
+      });
+
+    });
+
+  })
+
+})

--- a/test/uri_modifier_spec.js
+++ b/test/uri_modifier_spec.js
@@ -6,12 +6,12 @@ var needle  = require('../'),
 
 var port = 3456;
 
-describe('uri_mod config parameter function', function() {
+describe('uri_modifier config parameter function', function() {
 
   var server, uri;
 
   function send_request(mw, cb) {
-    return needle.get(uri, null, { uri_mod: mw }, cb);
+    return needle.get(uri, null, { uri_modifier: mw }, cb);
   }
 
   before(function(done){


### PR DESCRIPTION
This small code gives opportunity to 'intercept' and modify request URI on-the-fly. When application is used to crawl/visit over resources, making request in the automated way, in some cases it is needed to modify uri/querystring, basing on some rules - e.g. we know that for specific location additional querystring or chunk of path needs to be appended/removed.

Additionally, fixed a bug with `resp.cookies` being undefined if `follow_set_cookies` is enabled and previous response cookies not present and `set-cookie` headers is not present.