### PR TITLE
feat: allow needle to accept IP family as a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ These options are passed directly to `https.request` if present. Taken from the 
  - `ciphers`            : A string describing the ciphers to use or exclude.
  - `rejectUnauthorized` : If true, the server certificate is verified against the list of supplied CAs. An 'error' event is emitted if verification fails. Verification happens at the connection level, before the HTTP request is sent.
  - `secureProtocol`     : The SSL method to use, e.g. SSLv3_method to force SSL version 3.
+ - `family`             : IP address family to use when resolving host and hostname. Valid values are 4 or 6. When unspecified, both IP v4 and v6 will be used.
 
 Redirect options
 ----------------

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -26,7 +26,7 @@ var version     = require('../package.json').version;
 var user_agent  = 'Needle/' + version;
 user_agent     += ' (Node.js ' + process.version + '; ' + process.platform + ' ' + process.arch + ')';
 
-var tls_options = 'agent pfx key passphrase cert ca ciphers rejectUnauthorized secureProtocol checkServerIdentity';
+var tls_options = 'agent pfx key passphrase cert ca ciphers rejectUnauthorized secureProtocol checkServerIdentity family';
 
 // older versions of node (< 0.11.4) prevent the runtime from exiting
 // because of connections in keep-alive state. so if this is the case


### PR DESCRIPTION
Add the ability to pass IP family to `https.request()`