### PR TITLE
Added hpagent to proxy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,22 @@ var myAgent = tunnel.httpOverHttp({
 needle.get('foobar.com', { agent: myAgent });
 ```
 
+Otherwise, you can use the [`hpagent`](https://github.com/delvedor/hpagent) package, which keeps the internal sockets alive to be reused.
+
+```js
+const { HttpsProxyAgent } = require('hpagent');
+needle('get', 'https://localhost:9200', {
+  agent: new HttpsProxyAgent({
+    keepAlive: true,
+    keepAliveMsecs: 1000,
+    maxSockets: 256,
+    maxFreeSockets: 256,
+    scheduling: 'lifo',
+    proxy: 'https://localhost:8080'
+  })
+});
+```
+
 Regarding the 'Connection' header
 ---------------------------------
 


### PR DESCRIPTION
Hello!
I've spent the past days working on a [HTTP agent](https://github.com/delvedor/hpagent) for working with proxies that also keeps sockets alive. Since I wasn't able to find one, I built it.
I'm testing that the agent works with needle in my testing suite (https://github.com/delvedor/hpagent/pull/4). If you would like to mention the package in your README, this pr does that :)