### PR TITLE
Removed usage of deprecated API

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -549,8 +549,9 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
         config.headers['host'] = null; // clear previous Host header to avoid conflicts.
 
-        debug('Redirecting to ' + url.resolve(uri, headers.location));
-        return self.send_request(++count, method, url.resolve(uri, headers.location), config, post_data, out, callback);
+        let redirect_url = new url.URL(headers.location, uri);
+        debug('Redirecting to ' +  redirect_url.toString());
+        return self.send_request(++count, method, redirect_url.toString(), config, post_data, out, callback);
       } else if (config.follow_max > 0) {
         return done(new Error('Max redirects reached. Possible loop in: ' + headers.location));
       }


### PR DESCRIPTION
`url.resolve` is deprecated. https://nodejs.org/api/url.html#url_url_resolve_from_to