### PR TITLE
treat xml and json mime types as text

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -574,7 +574,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
     var pipeline      = [],
         mime          = parse_content_type(headers['content-type']),
-        text_response = mime.type && mime.type.indexOf('text/') != -1;
+        text_response = mime.type && (mime.type.indexOf('text/') != -1 || ["/json","+json"].indexOf(mime.type.slice(-5)) != -1 || ["/xml","+xml"].indexOf(mime.type.slice(-4)) != -1);
 
     // To start, if our body is compressed and we're able to inflate it, do it.
     if (headers['content-encoding'] && decompressors[headers['content-encoding']]) {

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -574,7 +574,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
     var pipeline      = [],
         mime          = parse_content_type(headers['content-type']),
-        text_response = mime.type && (mime.type.indexOf('text/') != -1 || ["/json","+json"].indexOf(mime.type.slice(-5)) != -1 || ["/xml","+xml"].indexOf(mime.type.slice(-4)) != -1);
+        text_response = mime.type && (mime.type.indexOf('text/') != -1 || !!mime.type.match(/(\/|\+)(xml|json)$/));
 
     // To start, if our body is compressed and we're able to inflate it, do it.
     if (headers['content-encoding'] && decompressors[headers['content-encoding']]) {

--- a/test/mimetype.js
+++ b/test/mimetype.js
@@ -1,0 +1,81 @@
+var should  = require('should'),
+  needle  = require('./../'),
+  helpers = require('./helpers');
+
+describe('receiving json and xml content as string', function() {
+
+  this.timeout(5000);
+
+  ["text/plain", "application/json", "application/ld+json", "application/xml", "image/svg+xml"].forEach(function(mimetype, offset){
+
+    describe('Given content-type: "'+mimetype+'"', function () {
+
+      var server, port = 54330+offset;
+
+      before(function(done) {
+        server = helpers.server({
+          port: port,
+          response: 'content',
+          headers: { 'Content-Type': mimetype }
+        }, done);
+      })
+
+      after(function(done) {
+        server.close(done)
+      })
+
+      describe('with parse = false', function () {
+        it('delivers by default as string', function (done) {
+
+          needle.get('http://localhost:' + port, { parse: false }, function (err, resp) {
+
+            resp.body.should.be.a.String;
+            (typeof resp.body).should.eql('string')
+            done();
+          })
+
+        })
+
+      })
+
+    })
+
+  });
+  
+  ["application/octet-stream", "image/png"].forEach(function(mimetype, offset){
+  
+    describe('Given content-type: "'+mimetype+'"', function () {
+
+      var server, port = 54340+offset;
+
+      before(function(done) {
+        server = helpers.server({
+          port: port,
+          response: 'content',
+          headers: { 'Content-Type': mimetype }
+        }, done);
+      })
+
+      after(function(done) {
+        server.close(done)
+      })
+
+      describe('with parse = false', function () {
+        it('delivers by default as Buffer', function (done) {
+
+          needle.get('http://localhost:' + port, { parse: false }, function (err, resp) {
+
+            resp.body.should.be.a.Buffer;
+            (resp.body instanceof Buffer).should.eql(true)
+            done();
+          })
+
+        })
+
+      })
+
+    })
+
+  })
+
+})


### PR DESCRIPTION
mime types such as `image/svg+xml` or `application/ld+json` should be returned as strings.