### PR TITLE
underscore in nonce breaks the digest request

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -32,7 +32,7 @@ var digest = {};
 
 digest.parse_header = function(header) {
   var challenge = {},
-      matches   = header.match(/([a-z0-9_-]+)="?([a-z0-9=\/\.@\s-\+)()]+)"?/gi);
+      matches   = header.match(/([a-z0-9_-]+)="?([a-z0-9_=\/\.@\s-\+)()]+)"?/gi);
 
   for (var i = 0, l = matches.length; i < l; i++) {
     var parts = matches[i].split('='),


### PR DESCRIPTION
underscore in nonce breaks the digest request causing 401 Unauthorized error.

Before:
<img width="1364" alt="before" src="https://user-images.githubusercontent.com/2654866/120729191-859cd900-c4ac-11eb-9024-17f2e383bd4c.png">

After:
<img width="1365" alt="after" src="https://user-images.githubusercontent.com/2654866/120729201-8b92ba00-c4ac-11eb-885c-470f83c2d9da.png">
