### PR TITLE
add lookup param for request

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -16,7 +16,8 @@ var fs          = require('fs'),
     auth        = require('./auth'),
     cookies     = require('./cookies'),
     parsers     = require('./parsers'),
-    decoder     = require('./decoder');
+    decoder     = require('./decoder'),
+    dns         = require('dns');
 
 //////////////////////////////////////////
 // variabilia
@@ -211,7 +212,8 @@ Needle.prototype.setup = function(uri, options) {
 
   var config = {
     http_opts : {
-      localAddress: get_option('localAddress', undefined)
+      localAddress: get_option('localAddress', undefined),
+      lookup: get_option('lookup', undefined)
     }, // passed later to http.request() directly
     headers   : {},
     output    : options.output,


### PR DESCRIPTION
http://nodejs.cn/api/http.html#http_http_request_url_options_callback

usage:

```
needle({
  url,
  lookup: (hostname, options, callback) => {
     if(hostname.endsWith('.localhost')) {
        setImmediate(() => {
           callback(null, '127.0.0.1', 4);
        });
        return
     }
     dns.lookup(hostname, options, callback);
  }
})
```