### PR TITLE
Add support for `application/vnd.api+json` content types

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -97,7 +97,8 @@ function buildParser(name, types, fn) {
 
 buildParser('json', [
   'application/json',
-  'text/javascript'
+  'text/javascript',
+  'application/vnd.api+json'
 ], function(buffer, cb) {
   var err, data;
   try { data = JSON.parse(buffer); } catch (e) { err = e; }

--- a/test/parsing_spec.js
+++ b/test/parsing_spec.js
@@ -421,7 +421,6 @@ describe('parsing', function(){
 
   })
 
-
   describe('valid XML, using xml2js', function() {
 
     var parsers, origParser;
@@ -490,5 +489,59 @@ describe('parsing', function(){
 
   })
 
+  describe('when response is a JSON API flavored JSON string', function () {
+
+    var json_string = '{"data":[{"type":"articles","id":"1","attributes":{"title":"Needle","body":"The leanest and most handsome HTTP client in the Nodelands."}}],"included":[{"type":"people","id":"42","attributes":{"name":"Tomás"}}]}';
+
+    before(function(done){
+      server = http.createServer(function(req, res) {
+        res.setHeader('Content-Type', 'application/vnd.api+json');
+        res.end(json_string);
+      }).listen(port, done);
+    });
+
+    after(function(done){
+      server.close(done);
+    });
+
+    describe('and parse option is not passed', function() {
+
+      describe('with default parse_response', function() {
+
+        before(function() {
+          needle.defaults().parse_response.should.eql('all')
+        })
+
+        it('should return object', function(done){
+          needle.get('localhost:' + port, function(err, response, body){
+            should.ifError(err);
+            body.should.deepEqual({
+              "data": [{
+                "type": "articles",
+                "id": "1",
+                "attributes": {
+                  "title": "Needle",
+                  "body": "The leanest and most handsome HTTP client in the Nodelands."
+                }
+              }],
+              "included": [
+                {
+                  "type": "people",
+                  "id": "42",
+                  "attributes": {
+                    "name": "Tomás"
+                  }
+                }
+              ]
+            });
+            done();
+          });
+        });
+
+      });
+
+    })
+
+  });
 
 })


### PR DESCRIPTION
Greetings!

It's been a while, but I ran into an API that returns something called JSON-API: https://jsonapi.org/

Apparently it's too good to use regular old `content-type: applcation/json`, and had to invent their own mime type. Needless to say, it's still JSON with a specialized format. Woohoo!

All sarcasm aside, this PR treats their `application/vnd.api+json` content mime type as json. 

Unit tests supporting the case added as well. Let me know how this looks and if there's anything else you need from me!

Thanks again,
-Kevin