### PR TITLE
Replace all .pipe calls with stream module pipeline method

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -614,9 +614,8 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     pipeline.push(out);
 
     // Now, release the kraken!
-    stream.pipeline(resp, ...pipeline, (error) => {
-      if (error) debug(error);
-    });
+    function pipelineCb(err) { if (err) debug(err) }
+    stream.pipeline.apply(null, [resp].concat(pipeline).concat(pipelineCb));
 
     // If the user has requested and output file, pipe the output stream to it.
     // In stream mode, we will still get the response stream to play with.
@@ -666,8 +665,8 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
         }
       })
 
-      stream.pipeline(resp, clean_pipe, (error) => {
-        if (error) debug(error);
+      stream.pipeline(resp, clean_pipe, function(err) {
+        if (err) debug(err);
       });
 
       // Listen on the 'readable' event to aggregate the chunks, but only if
@@ -757,8 +756,8 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
   if (post_data) {
     if (is_stream(post_data)) {
-      stream.pipeline(post_data, request, (error) => {
-        if (error) debug(error);
+      stream.pipeline(post_data, request, function(err) {
+        if (err) debug(err);
       });
     } else {
       request.write(post_data, config.encoding);

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -614,10 +614,9 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     pipeline.push(out);
 
     // Now, release the kraken!
-    var tmp = resp;
-    while (pipeline.length) {
-      tmp = tmp.pipe(pipeline.shift());
-    }
+    stream.pipeline(resp, ...pipeline, (error) => {
+      if (error) debug(error);
+    });
 
     // If the user has requested and output file, pipe the output stream to it.
     // In stream mode, we will still get the response stream to play with.
@@ -658,7 +657,6 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
       // Gather and count the amount of (raw) bytes using a PassThrough stream.
       var clean_pipe = new stream.PassThrough();
-      resp.pipe(clean_pipe);
 
       clean_pipe.on('readable', function() {
         var chunk;
@@ -667,6 +665,10 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
           resp.raw.push(chunk);
         }
       })
+
+      stream.pipeline(resp, clean_pipe, (error) => {
+        if (error) debug(error);
+      });
 
       // Listen on the 'readable' event to aggregate the chunks, but only if
       // file output wasn't requested. Otherwise we'd have two stream readers.
@@ -755,7 +757,9 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
   if (post_data) {
     if (is_stream(post_data)) {
-      post_data.pipe(request);
+      stream.pipeline(post_data, request, (error) => {
+        if (error) debug(error);
+      });
     } else {
       request.write(post_data, config.encoding);
       request.end();


### PR DESCRIPTION
In order to automatically forward any errors that might occur within the pipeline, and properly clean up afterwards, the stream.pipeline module method is preferred.

Fixes: #368, #280