### PR TITLE
Fix: thirdparty site authorization header leak

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -560,7 +560,15 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
           post_data = null;
           delete config.headers['content-length']; // in case the original was a multipart POST request.
         }
+          
+          
+        var redirect_hostname=url.parse(headers.location).hostname; //get redirect url hostname
+        //if original host and redirect host is different then remove Authorization header to prevent leak
+        if(redirect_hostname !== null && redirect_hostname !== config.headers['host']){
+          delete config.headers['authorization'];
+        }
 
+          
         // if follow_set_cookies is true, insert cookies in the next request's headers.
         // we set both the original request cookies plus any response cookies we might have received.
         if (config.follow_set_cookies) {


### PR DESCRIPTION
bug reported to https://huntr.dev/bounties/03ac704d-6ccf-4d4b-bed3-f123f4e31dcd/ 
When accessing a url with Authorization and if received a Location redirect header with different host then needle will follow this redirect and also send the Authorization to this thirdparty redirect url .
You must prevent this Authorization header leak .