### PR TITLE
fix: Fix test failures in node v14-v16

### DIFF
--- a/test/socket_cleanup_spec.js
+++ b/test/socket_cleanup_spec.js
@@ -61,7 +61,7 @@ describe('socket cleanup', function(){
 
     stream.pipeline(resp, writable, function(err) {
       err.code.should.eql('ERR_STREAM_PREMATURE_CLOSE')
-      // if (err) resp.request.destroy();
+      if (err) resp.request.destroy();
     });
 
     setTimeout(function() {


### PR DESCRIPTION
This fixes a failing socket cleanup test by destroying the request on
error.  This test did not fail on node v17.

Closes #395