### PR TITLE
fix: Fix test failures in node v4-v12

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -490,12 +490,11 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     out.done = true;
 
     // An error can still be fired after closing.  In particular, on macOS.
-    // Adding an explicit abort() call resolves this without leaving a dangling
-    // listener.  See also:
+    // See also:
     //  - https://github.com/tomas/needle/issues/391
     //  - https://github.com/less/less.js/issues/3693
     //  - https://github.com/nodejs/node/issues/27916
-    request.abort();
+    request.once('error', function() {});
 
     if (callback)
       return callback(err, resp, resp ? resp.body : undefined);


### PR DESCRIPTION
These failures were introduced by PR #392

Rather than abort the request, set up a listener to silence any errors
thrown late, as happens on macOS in certain node versions.

Closes #397