### PR TITLE
ci: add node18 test

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [4.x, 6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 17.x]
+        node-version: [4.x, 6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 17.x, 18.x]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Nodejs v18 be released recently and add it into tests matrix , https://nodejs.org/en/blog/announcements/v18-release-announce