### PR TITLE
Added query parameter to promise based get method

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -901,7 +901,7 @@ module.exports.defaults = function(obj) {
 
 'head get'.split(' ').forEach(function(method) {
   module.exports[method] = function(uri, options, callback) {
-    return new Needle(method, uri, null, options, callback).start();
+    return new Needle(method, uri, options.params, options, callback).start();
   }
 })
 

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -901,7 +901,7 @@ module.exports.defaults = function(obj) {
 
 'head get'.split(' ').forEach(function(method) {
   module.exports[method] = function(uri, options, callback) {
-    return new Needle(method, uri, options.params, options, callback).start();
+    return new Needle(method, uri, options.query, options, callback).start();
   }
 })
 


### PR DESCRIPTION
```javascript
needle.get(
        url,
        needleOptions,
        callback
)
```
Needle.get does not expect any query parameters from needle options. 