### PR TITLE
Add application/hal+json content-type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,13 @@ Then you should be able to run `npm test` once you have the dependencies in plac
 
 > Note: Tests currently only work on linux-based environments that have `/proc/self/fd`. They *do not* work on MacOS environments.
 > You can use Docker to run tests by creating a container and mounting the needle project directory on `/app`
-> `docker create --name Needle -v /app -w /app -v /app/node_modules -i node:argon`
+
+```bash
+# Located in your local cloned project :
+docker run -it -w /app --name Needle \
+--mount type=bind,source="$(pwd)",target=/app \
+node:fermium bash
+```
 
 Credits
 -------

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -97,6 +97,7 @@ function buildParser(name, types, fn) {
 
 buildParser('json', [
   'application/json',
+  'application/hal+json',
   'text/javascript',
   'application/vnd.api+json'
 ], function(buffer, cb) {

--- a/test/parsing_spec.js
+++ b/test/parsing_spec.js
@@ -544,4 +544,45 @@ describe('parsing', function(){
 
   });
 
+  describe('when response is a HAL JSON content-type', function () {
+
+    var json_string = '{"name": "Tomás", "_links": {"href": "https://github.com/tomas/needle.git"}}';
+
+    before(function(done){
+      server = http.createServer(function(req, res) {
+        res.setHeader('Content-Type', 'application/hal+json');
+        res.end(json_string);
+      }).listen(port, done);
+    });
+
+    after(function(done){
+      server.close(done);
+    });
+
+    describe('and parse option is not passed', function() {
+
+      describe('with default parse_response', function() {
+
+        before(function() {
+          needle.defaults().parse_response.should.eql('all')
+        })
+
+        it('should return object', function(done){
+          needle.get('localhost:' + port, function(err, response, body){
+            should.ifError(err);
+            body.should.deepEqual({
+              'name': 'Tomás',
+              '_links': {
+                'href': 'https://github.com/tomas/needle.git'
+              }});
+            done();
+          });
+        });
+
+      });
+
+    })
+
+  });
+
 })


### PR DESCRIPTION
Hello,

I found out that the HAL media type extension to JSON `content-type: application/hal+json` is not currently supported on Needle.
https://www.innoq.com/en/articles/2020/12/rest-apis-with-hal/

I would like to propose with this PR to manage application/hal+json parsing it as JSON.
I added a test as well to check this new content-type capability.

I managed to execute tests via docker and I would like to propose to modify the docker command line on the README file, in order to directly run the container and being able to execute npm tests afterwards.

Please let me know if you have any questions or remarks.
Many thanks,
Loïc