### PR TITLE
Fix multiple cookies for follow_set_cookies

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -20,7 +20,7 @@ var SEP_SEMICOLON      = /\s*\x3B\s*/;
 var KEY_INDEX   = 1; // index of key from COOKIE_PAIR match
 var VALUE_INDEX = 3; // index of value from COOKIE_PAIR match
 
-// Returns a copy str trimmed and without trainling semicolon.
+// Returns a copy str trimmed and without trailing semicolon.
 function cleanCookieString(str) {
   return str.trim().replace(/\x3B+$/, '');
 }
@@ -53,6 +53,7 @@ function parseSetCookieString(str) {
 // Each key represents the name of a cookie.
 function parseSetCookieHeader(header) {
   if (!header) return {};
+  if (typeof header === 'string' || header instanceof String) header = header.split(';');
   header = Array.isArray(header) ? header : [header];
 
   return header.reduce(function(res, str) {

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -542,7 +542,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
         // if follow_set_cookies is true, insert cookies in the next request's headers.
         // we set both the original request cookies plus any response cookies we might have received.
         if (config.follow_set_cookies && utils.host_and_ports_match(headers.location, uri)) {
-          var request_cookies = cookies.read(config.headers['cookie']);
+          var request_cookies = cookies.read(config.headers['cookie'].split(';'));
           config.previous_resp_cookies = resp.cookies;
           if (Object.keys(request_cookies).length || Object.keys(resp.cookies || {}).length) {
             config.headers['cookie'] = cookies.write(extend(request_cookies, resp.cookies));

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -542,7 +542,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
         // if follow_set_cookies is true, insert cookies in the next request's headers.
         // we set both the original request cookies plus any response cookies we might have received.
         if (config.follow_set_cookies && utils.host_and_ports_match(headers.location, uri)) {
-          var request_cookies = cookies.read(config.headers['cookie'].split(';'));
+          var request_cookies = cookies.read(config.headers['cookie']);
           config.previous_resp_cookies = resp.cookies;
           if (Object.keys(request_cookies).length || Object.keys(resp.cookies || {}).length) {
             config.headers['cookie'] = cookies.write(extend(request_cookies, resp.cookies));

--- a/test/cookies_spec.js
+++ b/test/cookies_spec.js
@@ -265,6 +265,41 @@ describe('cookies', function() {
 
         })
 
+        describe('with multiple original request cookies', function() {
+
+          var opts = {
+            follow_set_cookies: true,
+            follow_max: 4,
+            cookies: { 'xxx': 123, 'yyy': 456 }
+          };
+
+          it('request cookie is passed passed to redirects, and response cookies are added too', function(done) {
+            needle.get('localhost:' + testPort + '/0', opts, function(err, resp) {
+              requestCookies.should.eql([
+                "xxx=123; yyy=456",
+                "xxx=123; yyy=456; wc=!'*+#()&-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~; bc=Y29va2llCg==; FOO=123",
+                "xxx=123; yyy=456; wc=!\'*+#()&-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~; bc=Y29va2llCg==; FOO=123; fc=%20%3B%22%5C%2C; nc=12354342",
+                "xxx=123; yyy=456; wc=!\'*+#()&-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~; bc=Y29va2llCg==; FOO=BAR; fc=%20%3B%22%5C%2C; nc=12354342",
+                "xxx=123; yyy=456; wc=!\'*+#()&-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~; bc=Y29va2llCg==; FOO=BAR; fc=%20%3B%22%5C%2C; nc=12354342"
+              ])
+              done();
+            });
+          });
+
+          it('response cookies are passed as well', function(done) {
+            needle.get('localhost:' + testPort + '/0', opts, function(err, resp) {
+              resp.cookies.should.have.property(WEIRD_COOKIE_NAME);
+              resp.cookies.should.have.property(BASE64_COOKIE_NAME);
+              resp.cookies.should.have.property(FORBIDDEN_COOKIE_NAME);
+              resp.cookies.should.have.property(NUMBER_COOKIE_NAME);
+              resp.cookies.should.have.property('FOO');
+              resp.cookies.FOO.should.eql('BAR'); // should overwrite previous one
+              done();
+            });
+          });
+
+        })
+
         describe('without original request cookie', function() {
 
           var opts = {
@@ -287,12 +322,12 @@ describe('cookies', function() {
 
           it('response cookies are passed as well', function(done) {
             needle.get('localhost:' + testPort + '/0', opts, function(err, resp) {
-              // resp.cookies.should.have.property(WEIRD_COOKIE_NAME);
-              // resp.cookies.should.have.property(BASE64_COOKIE_NAME);
-              // resp.cookies.should.have.property(FORBIDDEN_COOKIE_NAME);
-              // resp.cookies.should.have.property(NUMBER_COOKIE_NAME);
-              // resp.cookies.should.have.property('FOO');
-              // resp.cookies.FOO.should.eql('BAR'); // should overwrite previous one
+              resp.cookies.should.have.property(WEIRD_COOKIE_NAME);
+              resp.cookies.should.have.property(BASE64_COOKIE_NAME);
+              resp.cookies.should.have.property(FORBIDDEN_COOKIE_NAME);
+              resp.cookies.should.have.property(NUMBER_COOKIE_NAME);
+              resp.cookies.should.have.property('FOO');
+              resp.cookies.FOO.should.eql('BAR'); // should overwrite previous one
               done();
             });
           });


### PR DESCRIPTION
It appears that cookies.js expects the format ofthe `Set Cookies` header to function. This sounds reasonable, but the original request's cookies are stored as a string (for convenience I believe?) not as key-value pair strings, so it needs to be separated again to be forwarded correctly in the redirect.

Fixes #350.