### PR TITLE
feat: add option to disable use_proxy_from_env_var

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -106,7 +106,8 @@ var defaults = {
   follow_keep_method      : false,
   follow_if_same_host     : false,
   follow_if_same_protocol : false,
-  follow_if_same_location : false
+  follow_if_same_location : false,
+  use_proxy_from_env_var  : true
 }
 
 var aliased = {
@@ -255,12 +256,14 @@ Needle.prototype.setup = function(uri, options) {
     }
   }
 
-  var env_proxy = utils.get_env_var(['HTTP_PROXY', 'HTTPS_PROXY'], true);
-  if (!config.proxy && env_proxy) config.proxy = env_proxy;
+  if (config.use_proxy_from_env_var) {
+    var env_proxy = utils.get_env_var(['HTTP_PROXY', 'HTTPS_PROXY'], true);
+    if (!config.proxy && env_proxy) config.proxy = env_proxy;
+  }
 
   // if proxy is present, set auth header from either url or proxy_user option.
   if (config.proxy) {
-    if (utils.should_proxy_to(uri)) {
+    if (!config.use_proxy_from_env_var || utils.should_proxy_to(uri)) {
       if (config.proxy.indexOf('http') === -1)
         config.proxy = 'http://' + config.proxy;
 

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -228,4 +228,41 @@ describe('proxy option', function() {
 
   })
 
+  describe('when environment variable is set', function() {
+
+    describe('and default is unchanged', function() {
+
+      before(function() {
+        process.env.HTTP_PROXY = 'foobar';
+      })
+
+      after(function() {
+        delete process.env.HTTP_PROXY;
+      })
+
+      it('tries to proxy', function(done) {
+        send_request({}, proxied('foobar', 80, done))
+      })
+
+    })
+
+    describe('and functionality is disabled', function() {
+
+      before(function() {
+        process.env.HTTP_PROXY = 'foobar';
+      })
+
+      after(function() {
+        delete process.env.HTTP_PROXY;
+      })
+
+      it('ignores proxy', function(done) {
+        send_request({
+          use_proxy_from_env_var: false
+        }, not_proxied(done))
+      })
+
+    })
+  })
+
 })


### PR DESCRIPTION
**What**

This introduces an option to disable the functionality introduced in https://github.com/tomas/needle/pull/382 and addresses https://github.com/tomas/needle/issues/406. It keeps the default behaviour, but allows opting out of needle picking up proxy configuration from environment variables.

**Why**

Automatic use of environment variables for proxy configuration causes issues if the http agent should be extended with specific proxy features, for example, when using https://github.com/gajus/global-agent.
