### PR TITLE
Destroy original digest auth request prior to making new one

### DIFF
--- a/lib/needle.js
+++ b/lib/needle.js
@@ -572,7 +572,7 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
         if (auth_header) {
           config.headers['authorization'] = auth_header;
-		  // Destroy the old request to prevent the unauthenticated digest request from causing the needle promise to catch/reject
+          // Destroy the old request to prevent the unauthenticated digest request from causing the needle promise to catch/reject
           // This is especially an issue with application/octet-stream request bodies where the server can cause the connection to reset
           request.destroy();
 

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -572,6 +572,10 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
 
         if (auth_header) {
           config.headers['authorization'] = auth_header;
+		  // Destroy the old request to prevent the unauthenticated digest request from causing the needle promise to catch/reject
+          // This is especially an issue with application/octet-stream request bodies where the server can cause the connection to reset
+          request.destroy();
+
           return self.send_request(count, method, uri, config, post_data, out, callback);
         }
       }


### PR DESCRIPTION
As mentioned in the comment in the code, the digest authentication process can result in the first request erroring out naturally. This error will make the entire needle request catch/reject. If we first destroy this old request, and then make the new one, the properly authenticated digest request may proceed regardless of the fate of the original digest request.